### PR TITLE
[Feat] 그래프 구조 수정 및 단순 응답 플로우 동작

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -4,10 +4,11 @@ from dataclasses import dataclass
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.pregel import Pregel
 
+from agents.workflows.maingraph import graph as tutor_graph
 from schema import AgentInfo
 
-# 기본 에이전트 키(아직 구현되지 않은 기본 에이전트)
-DEFAULT_AGENT = ""
+# 기본 에이전트 키
+DEFAULT_AGENT = "tutor"
 
 # LangGraph의 다양한 에이전트 패턴을 다루기 위한 타입 별칭
 # - @entrypoint 함수는 Pregel 을 반환
@@ -23,7 +24,12 @@ class Agent:
 
 
 # 에이전트 레지스트리 - (key: 에이전트 ID, value: Agent)
-agents: dict[str, Agent] = {}
+agents: dict[str, Agent] = {
+    "tutor": Agent(
+        description="Proovy 수학/과학 튜터 에이전트",
+        graph_like=tutor_graph,
+    ),
+}
 
 
 def get_agent(agent_id: str) -> AgentGraph:

--- a/src/agents/state.py
+++ b/src/agents/state.py
@@ -70,6 +70,7 @@ class AgentState(TypedDict):
     feature_results: Annotated[List[Dict[str, Any]], operator.add]
     solve_result: Optional[SolveResult] = None
     explain_result: Optional[ExplainResult] = None
+
     graph_result: Optional[GraphResult] = None
     variant_result: Optional[VariantResult] = None
     solution_result: Optional[SolutionResult] = None

--- a/src/agents/state.py
+++ b/src/agents/state.py
@@ -81,6 +81,7 @@ class AgentState(TypedDict):
     prev_action: Optional[str]
     next_action: Optional[str]
     simple_response: Optional[bool] = None
+    retry_limit_exceeded: Optional[bool] = None
 
     # Tool/최종 (기본값 추가)
     tool_outputs: Dict[str, Any] = {}

--- a/src/agents/state.py
+++ b/src/agents/state.py
@@ -77,6 +77,11 @@ class AgentState(TypedDict):
     # Review Layer
     review_state: ReviewState
 
+    # Routing context
+    prev_action: Optional[str]
+    next_action: Optional[str]
+    simple_response: Optional[bool] = None
+
     # Tool/최종 (기본값 추가)
     tool_outputs: Dict[str, Any] = {}
     final_output: Dict[str, Any] = {}

--- a/src/agents/workflows/maingraph.py
+++ b/src/agents/workflows/maingraph.py
@@ -35,7 +35,7 @@ from agents.workflows.subgraphs.step4_features import (
 FEATURE_MAP = {
     "solve": solve_graph,
     "explain": explain_graph,
-    "create_graph": create_graph_graph,
+    "CreateGraph": create_graph_graph,
     "variant": variant_graph,
     "solution": solution_graph,
     "check": check_graph,
@@ -105,7 +105,7 @@ def simple_response(state: AgentState) -> AgentState:
 
     # LangGraph state reducer(add_messages)를 이용해 새 AI 메시지를 추가
     state["messages"] = (messages or []) + [ai_message]
-    state["prev_action"] = "Simple_response"
+    state["prev_action"] = "SimpleResponse"
     return state
 
 
@@ -177,7 +177,7 @@ builder.add_conditional_edges(
     {
         "Solve": "Solve",
         "Explain": "Explain",
-        "Create_graph": "Create_graph",
+        "CreateGraph": "CreateGraph",
         "Variant": "Variant",
         "Solution": "Solution",
         "Check": "Check",

--- a/src/agents/workflows/maingraph.py
+++ b/src/agents/workflows/maingraph.py
@@ -128,7 +128,8 @@ builder.add_node("Router", router_graph)
 builder.add_node("RAG", rag_graph)
 # 2. Feature 서브그래프 노드들
 for name, graph_obj in FEATURE_MAP.items():
-    builder.add_node(name.capitalize(), graph_obj)
+    # name.capitalize()는 'CreateGraph' -> 'Creategraph'가 되므로, CamelCase는 그대로 써야 함
+    builder.add_node(name, graph_obj)
 # 3. Main 그래프 자체 노드
 builder.add_node("Review", review)
 builder.add_node("Suggestion", suggestion)
@@ -165,7 +166,7 @@ def route_to_feature(state: AgentState) -> str:
     if state.get("retry_limit_exceeded"):
         return "Fallback"
 
-    step = state.get("current_step", "").capitalize()
+    step = state.get("current_step", "")
     if step in builder.nodes:
         return step
     # 플랜의 마지막 단계였거나, 스텝이 없는 경우

--- a/src/agents/workflows/maingraph.py
+++ b/src/agents/workflows/maingraph.py
@@ -31,12 +31,12 @@ from agents.workflows.subgraphs.step4_features import (
 # --- Feature 서브그래프 매핑 ---
 # StepRouter의 결과('solve', 'explain' 등)와 실제 그래프 객체를 연결합니다.
 FEATURE_MAP = {
-    "solve": solve_graph,
-    "explain": explain_graph,
+    "Solve": solve_graph,
+    "Explain": explain_graph,
     "CreateGraph": create_graph_graph,
-    "variant": variant_graph,
-    "solution": solution_graph,
-    "check": check_graph,
+    "Variant": variant_graph,
+    "Solution": solution_graph,
+    "Check": check_graph,
 }
 
 # --- Main Graph Nodes (서브그래프에 없는 노드들) ---
@@ -203,7 +203,7 @@ def route_after_feature(state: AgentState) -> str:
 # 각 Feature 노드 실행 후에는 route_after_feature 함수를 통해 분기합니다.
 for name in FEATURE_MAP:
     builder.add_conditional_edges(
-        name.capitalize(),
+        name,
         route_after_feature,
         {
             "Router": "Router",

--- a/src/agents/workflows/maingraph.py
+++ b/src/agents/workflows/maingraph.py
@@ -113,6 +113,8 @@ builder.add_edge("RAG", "Router")
 # 해당하는 Feature 노드로 분기합니다.
 def route_to_feature(state: AgentState) -> str:
     # Flowchart: "StepRouter"
+    if state.get("retry_limit_exceeded"):
+        return "Fallback"
     step = state.get("current_step", "").capitalize()
     if step in builder.nodes:
         return step
@@ -131,6 +133,7 @@ builder.add_conditional_edges(
         "Solution": "Solution",
         "Check": "Check",
         "Review": "Review",
+        "Fallback": "Fallback",
     },
 )
 

--- a/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
+++ b/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
@@ -16,6 +16,7 @@ def check_type(state: AgentState) -> AgentState:
     # TODO: 실제 파일 타입 체크 로직 구현
     # state['check_result'] = "text_only"  # 또는 "image_only", "mixed_files"
     print("---CHECKING INPUT TYPE---")
+    state["prev_action"] = "Preprocessing"
     return state
 
 
@@ -28,6 +29,8 @@ def file_convert(state: AgentState) -> AgentState:
 def vision_llm(state: AgentState) -> AgentState:
     """이미지 분석 - OCR + 캡셔닝 (stub)."""
     print("---PROCESSING WITH VISION LLM---")
+    state["prev_action"] = "Preprocessing"
+    state["next_action"] = "Intent"
     return state
 
 
@@ -47,6 +50,8 @@ def route_by_check_type(
     elif "image_only" in check_result:
         return "VisionLLM"
     else:  # "text_only"
+        state["prev_action"] = "Preprocessing"
+        state["next_action"] = "Intent"
         return "__end__"
 
 

--- a/src/agents/workflows/subgraphs/step2_router/graph.py
+++ b/src/agents/workflows/subgraphs/step2_router/graph.py
@@ -78,8 +78,10 @@ def retry_counter(state: AgentState) -> Literal["Executor", "__end__"]:
     retries = state.get("retry_count", 0) + 1
     state["retry_count"] = retries
     if retries > MAX_RETRIES:
+        state["retry_limit_exceeded"] = True
         print(f"---ROUTER: RETRY LIMIT EXCEEDED ({retries - 1})---")
         return "__end__"
+    state.pop("retry_limit_exceeded", None)
     print(f"---ROUTER: RETRYING ({retries - 1}/{MAX_RETRIES})---")
     return "Executor"
 

--- a/src/agents/workflows/subgraphs/step2_router/graph.py
+++ b/src/agents/workflows/subgraphs/step2_router/graph.py
@@ -25,7 +25,7 @@ MAX_RETRIES = 2
 FEATURE_ACTIONS = {
     "Solve",
     "Explain",
-    "Create_graph",
+    "CreateGraph",
     "Variant",
     "Solution",
     "Check",

--- a/src/agents/workflows/subgraphs/step3_rag/graph.py
+++ b/src/agents/workflows/subgraphs/step3_rag/graph.py
@@ -17,7 +17,18 @@ def embedding_search(state: AgentState) -> AgentState:
 def relevance_check(state: AgentState) -> AgentState:
     """유사도 threshold 체크 (stub)."""
 
+    tool_outputs = state.setdefault("tool_outputs", {})
+    retrieved_docs = tool_outputs.get("retrieved_docs")
+    tool_outputs["rag_relevance_passed"] = bool(retrieved_docs)
+
     return state
+
+
+def relevance_check_decision(state: AgentState) -> str:
+    """RelevanceCheck 이후 분기 제어."""
+
+    tool_outputs = state.get("tool_outputs") or {}
+    return "inject_docs" if tool_outputs.get("rag_relevance_passed") else "skip_docs"
 
 
 def retrieved_docs(state: AgentState) -> AgentState:
@@ -33,7 +44,14 @@ builder.add_node("RetrievedDocs", retrieved_docs)
 
 builder.set_entry_point("EmbeddingSearch")
 builder.add_edge("EmbeddingSearch", "RelevanceCheck")
-builder.add_edge("RelevanceCheck", "RetrievedDocs")
+builder.add_conditional_edges(
+    "RelevanceCheck",
+    relevance_check_decision,
+    {
+        "inject_docs": "RetrievedDocs",
+        "skip_docs": END,
+    },
+)
 builder.add_edge("RetrievedDocs", END)
 
 graph = builder.compile()

--- a/src/agents/workflows/subgraphs/step3_rag/graph.py
+++ b/src/agents/workflows/subgraphs/step3_rag/graph.py
@@ -28,6 +28,8 @@ def relevance_check_decision(state: AgentState) -> str:
     """RelevanceCheck 이후 분기 제어."""
 
     tool_outputs = state.get("tool_outputs") or {}
+    state["prev_action"] = "RAG"
+    state["next_action"] = "IntentRoute"
     return "inject_docs" if tool_outputs.get("rag_relevance_passed") else "skip_docs"
 
 

--- a/src/agents/workflows/subgraphs/step4_features/check/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/check/graph.py
@@ -9,6 +9,8 @@ def check(state: AgentState) -> AgentState:
     """풀이 검토 기능 (stub)."""
     print("---FEATURE: CHECK---")
     # TODO: Implement actual logic for check
+    state["prev_action"] = "Check"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/agents/workflows/subgraphs/step4_features/create_graph/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/create_graph/graph.py
@@ -9,6 +9,8 @@ def create_graph(state: AgentState) -> AgentState:
     """그래프 생성 기능 (stub)."""
     print("---FEATURE: CREATE_GRAPH---")
     # TODO: Implement actual logic for create_graph
+    state["prev_action"] = "Create_graph"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/agents/workflows/subgraphs/step4_features/create_graph/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/create_graph/graph.py
@@ -9,7 +9,7 @@ def create_graph(state: AgentState) -> AgentState:
     """그래프 생성 기능 (stub)."""
     print("---FEATURE: CREATE_GRAPH---")
     # TODO: Implement actual logic for create_graph
-    state["prev_action"] = "Create_graph"
+    state["prev_action"] = "CreateGraph"
     state["next_action"] = "Executor"
     return state
 

--- a/src/agents/workflows/subgraphs/step4_features/explain/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/explain/graph.py
@@ -9,6 +9,8 @@ def explain(state: AgentState) -> AgentState:
     """개념 설명 기능 (stub)."""
     print("---FEATURE: EXPLAIN---")
     # TODO: Implement actual logic for explain
+    state["prev_action"] = "Explain"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/agents/workflows/subgraphs/step4_features/solution/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/solution/graph.py
@@ -9,6 +9,8 @@ def solution(state: AgentState) -> AgentState:
     """해설 기능 (stub)."""
     print("---FEATURE: SOLUTION---")
     # TODO: Implement actual logic for solution
+    state["prev_action"] = "Solution"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/agents/workflows/subgraphs/step4_features/solve/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/solve/graph.py
@@ -9,6 +9,8 @@ def solve(state: AgentState) -> AgentState:
     """문제 풀이 기능 (stub)."""
     print("---FEATURE: SOLVE---")
     # TODO: Implement actual logic for solve
+    state["prev_action"] = "Solve"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/agents/workflows/subgraphs/step4_features/variant/graph.py
+++ b/src/agents/workflows/subgraphs/step4_features/variant/graph.py
@@ -9,6 +9,8 @@ def variant(state: AgentState) -> AgentState:
     """유사 문제 생성 기능 (stub)."""
     print("---FEATURE: VARIANT---")
     # TODO: Implement actual logic for variant
+    state["prev_action"] = "Variant"
+    state["next_action"] = "Executor"
     return state
 
 

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -32,6 +32,7 @@ class OpenRouterModelName(StrEnum):
 
     GPT_5 = "openai/gpt-5"
     GPT_5_CODEX = "openai/gpt-5-codex"
+    GPT_5_MINI = "openai/gpt-5-mini"
     GPT_5_1_OPENROUTER = "openai/gpt-5.1"
     GPT_5_1_CODEX = "openai/gpt-5.1-codex"
     GPT_5_1_CODEX_MAX = "openai/gpt-5.1-codex-max"


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #6 


## 🏷️ PR 타입
- ✨ 기능 추가 (Feature)


## 📝 작업 내용
- subgraphs, maingraphs 구조 수정
-  state에 prev_action, next_action, simple_response 변수 추가
-  agents.py에 maingraph.py를 "tutor"라는 이름으로 추가
- 의도 감지, 단순 응답 노드 구현


## 📸 스크린샷
- <img width="1539" height="741" alt="{F0D30818-321A-4B1D-AC2F-95BBE35A6574}" src="https://github.com/user-attachments/assets/e10d7230-08e9-4c2c-9935-e8fc588f6761" />
: 이공계 과목 외의 질문에 대한 intent 감지 후 simple response로 분기, 응답 


## ✅ 체크리스트
- [v] 텍스트 입력 → Intent 감지 → 단순 응답 플로우 동작
- [v] OpenRouter LLM 호출 성공


## 📎 기타 참고사항
- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 기본 튜터 에이전트 자동 설정 추가
  * 간단 응답(Simple response) 생성 모드 추가
  * GPT‑5‑mini 모델 지원 추가

* **Improvements**
  * STEM/비‑STEM 자동 분류 도입
  * 라우팅 흐름의 다중 진입 및 동적 라우팅 강화
  * 재시도 로직 개선 및 재시도 한도 표시
  * 워크플로우 상태(prev/next 액션, 단순 응답 플래그 등) 추적 향상

* **Refactor**
  * 리뷰와 피처 전환 로직 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->