### PR TITLE
[Fix] FinalResponse 결과를 SSE로 전송하도록 처리

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -378,8 +378,12 @@ async def message_generator(
                         else:
                             update_messages = []
 
-                    # 중간 노드의 update_messages는 클라이언트로 전달하지 않기 위해 버린다.
-                    # 최종 응답 노드의 update_messages도 토큰 스트림으로 충분하므로 별도 전송하지 않는다.
+                    # FinalResponse 노드가 partial_responses를 조합한 경우
+                    # LLM 호출 없이 문자열만 합치므로 토큰 스트림이 발생하지 않는다.
+                    # 이 경우 update_messages에 담긴 최종 AIMessage를 직접 전송한다.
+                    if is_final_node(node_path) and update_messages:
+                        new_messages.extend(update_messages)
+                    # 그 외 중간 노드의 update_messages는 클라이언트로 전달하지 않는다.
 
             if stream_mode == "custom":
                 new_messages = [event]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #46 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- `service.py`의 `message_generator`에서 FinalResponse 노드일 때 `update_messages`를 버리지 않고 SSE 전송 대상으로 포함
- FinalResponse가 concat 방식으로 응답을 만들 때도 클라이언트가 최종 답변을 수신하도록 보장

## 📸 스크린샷


## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다 (또는 수동 테스트 완료)
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

FinalResponse가 `partial_responses`를 조합하는 경우에는 LLM 호출이 발생하지 않아 토큰 스트리밍이 생성되지 않습니다.
따라서 FinalResponse의 `update_messages`에 담긴 최종 AIMessage를 직접 SSE 전송 대상으로 포함시키는 방식으로 해결했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 최종 응답 메시지가 토큰 스트림에 올바르게 포함되어 전달되도록 개선했습니다.
  * 스트리밍 처리 시 메시지 전달의 완성도를 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->