### PR TITLE
[Fix] FinalResponse 노드 체크 수정

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -381,7 +381,7 @@ async def message_generator(
                     # FinalResponse 노드가 partial_responses를 조합한 경우
                     # LLM 호출 없이 문자열만 합치므로 토큰 스트림이 발생하지 않는다.
                     # 이 경우 update_messages에 담긴 최종 AIMessage를 직접 전송한다.
-                    if is_final_node(node_path) and update_messages:
+                    if node_name == "FinalResponse" and update_messages:
                         new_messages.extend(update_messages)
                     # 그 외 중간 노드의 update_messages는 클라이언트로 전달하지 않는다.
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #46 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용
- `subgraphs=True` 환경에서 `node_path`가 그래프 경로 튜플로 내려와 `"FinalResponse"`를 포함하지 않아, `is_final_node(node_path)`가 항상 `False`가 되는 문제를 수정했습니다.
- 실제 노드 이름(`node_name`) 기준으로 `"FinalResponse"` 여부를 판별하도록 변경하여, 최종 응답 조합 케이스에서도 `update_messages`에 담긴 최종 AIMessage가 정상 전송되도록 했습니다.
- 변경 파일: `Proovy-ai/src/service/service.py`

## 📸 스크린샷

<img width="785" height="701" alt="image" src="https://github.com/user-attachments/assets/48e65b8b-056d-4e5b-a52e-ee80d9fbd06f" />

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다 (또는 수동 테스트 완료)
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항
- 최종 응답이 LLM 토큰 스트림 없이 `partial_responses`를 조합하는 케이스에서, 기존 로직이 `node_path` 기준 판별 실패로 최종 메시지를 누락하던 문제가 해결됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 스트리밍 기능에서 최종 응답 감지 로직을 개선했습니다. 최종 AI 응답의 전송 시점이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->