### PR TITLE
[Fix] s3 url 인식 불가 버그

### DIFF
--- a/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
+++ b/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
@@ -15,6 +15,7 @@ from agents.workflows.subgraphs.step1_preprocessing.vision_llm import analyze_im
 
 # --- 헬퍼들  ---
 
+
 def _model_copy(fp: FileProcessing, update: Dict[str, Any]) -> FileProcessing:
     """Pydantic v2 환경: model_copy(update=...)로 새 인스턴스 반환."""
     return fp.model_copy(update=update)
@@ -29,6 +30,13 @@ def _ensure_fp(state: AgentState) -> FileProcessing:
 
 def _is_s3_uri(uri: Optional[str]) -> bool:
     return isinstance(uri, str) and uri.startswith("s3://")
+
+
+def _is_http_url(uri: Optional[str]) -> bool:
+    """HTTP/HTTPS URL인지 확인 (S3 공개 URL 포함)"""
+    return isinstance(uri, str) and (
+        uri.startswith("http://") or uri.startswith("https://")
+    )
 
 
 def _infer_file_type(input_path_str: Optional[str]) -> str:
@@ -50,9 +58,14 @@ def _infer_file_type(input_path_str: Optional[str]) -> str:
 
 def _localize_input_path(input_path_str: str, tmp_dir: Path) -> Path:
     """
-    s3:// URI면 preprocessing_utils.download_s3_to_local을 호출해 로컬 Path 반환.
+    원격 파일(s3://, http://, https://)이면 로컬로 다운로드한 뒤 Path 반환.
     로컬이면 Path로 바로 반환.
     """
+    # HTTP/HTTPS URL인 경우 (S3 공개 URL 포함)
+    if _is_http_url(input_path_str):
+        return preprocessing_utils.download_from_url(input_path_str, tmp_dir)
+
+    # s3:// URI인 경우 (boto3 사용 필요)
     if _is_s3_uri(input_path_str):
         if not hasattr(preprocessing_utils, "download_s3_to_local"):
             raise RuntimeError(
@@ -60,6 +73,8 @@ def _localize_input_path(input_path_str: str, tmp_dir: Path) -> Path:
                 "함수가 구현되어 있어야 합니다."
             )
         return preprocessing_utils.download_s3_to_local(input_path_str, tmp_dir)
+
+    # 로컬 파일 경로
     return Path(input_path_str)
 
 
@@ -69,7 +84,15 @@ def _extract_path_from_file_item(item: Any) -> Optional[str]:
     if isinstance(item, (str, Path)):
         return str(item)
     if isinstance(item, dict):
-        for key in ("path", "file_path", "url", "s3_uri", "filename", "name", "file_name"):
+        for key in (
+            "path",
+            "file_path",
+            "url",
+            "s3_uri",
+            "filename",
+            "name",
+            "file_name",
+        ):
             value = item.get(key)
             if value:
                 return str(value)
@@ -102,7 +125,9 @@ def _collect_input_paths(state: AgentState, tool_outputs: Dict[str, Any]) -> Lis
     return unique
 
 
-def _primary_input_path(state: AgentState, tool_outputs: Dict[str, Any]) -> Optional[str]:
+def _primary_input_path(
+    state: AgentState, tool_outputs: Dict[str, Any]
+) -> Optional[str]:
     paths = _collect_input_paths(state, tool_outputs)
     return paths[0] if paths else None
 
@@ -122,13 +147,14 @@ def _pick_preferred_path(paths: List[str], preferred: set[str]) -> Optional[str]
     return paths[0] if paths else None
 
 
-
 def check_type(state: AgentState) -> AgentState:
     """파일 유형 판별 및 file_processing.file_type 업데이트."""
     print("--- CHECKTYPE ---")
     tool_outputs = state.get("tool_outputs") or {}
     paths = _collect_input_paths(state, tool_outputs)
-    inferred = _infer_primary_type_from_paths(paths) if paths else _infer_file_type(None)
+    inferred = (
+        _infer_primary_type_from_paths(paths) if paths else _infer_file_type(None)
+    )
     if inferred == "pdf":
         category = "mixed_files"
     elif inferred == "image":
@@ -228,7 +254,9 @@ def vision_llm(state: AgentState) -> AgentState:
     return state
 
 
-def route_by_check_type(state: AgentState) -> Literal["FileConvert", "VisionLLM", "__end__"]:
+def route_by_check_type(
+    state: AgentState,
+) -> Literal["FileConvert", "VisionLLM", "__end__"]:
     """파일 형식에 따라 다음 단계를 결정합니다.
 
     - mixed_files: PDF/PPT 등 변환이 필요한 파일이 포함된 경우 'FileConvert'로 갑니다.

--- a/src/agents/workflows/subgraphs/step1_preprocessing/preprocessing_utils.py
+++ b/src/agents/workflows/subgraphs/step1_preprocessing/preprocessing_utils.py
@@ -1,8 +1,10 @@
 import os
 import logging
 import shutil
+import urllib.request
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+from urllib.parse import urlparse, unquote
 
 from pdf2image import convert_from_path
 from pdf2image.exceptions import PDFInfoNotInstalledError
@@ -15,6 +17,48 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 POPPLER_PATH = os.getenv("POPPLER_PATH", None)
+
+
+def is_http_url(uri: Optional[str]) -> bool:
+    """HTTP/HTTPS URL인지 확인"""
+    return isinstance(uri, str) and (
+        uri.startswith("http://") or uri.startswith("https://")
+    )
+
+
+def download_from_url(url: str, target_dir: Path) -> Path:
+    """
+    HTTP/HTTPS URL에서 파일을 다운로드하여 로컬 경로로 반환.
+    S3 presigned URL 또는 일반 공개 URL 모두 지원.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # URL에서 파일명 추출
+    parsed = urlparse(url)
+    path_part = parsed.path.split("?")[0]  # query string 제거
+    filename = unquote(path_part.split("/")[-1])  # URL 디코딩
+
+    if not filename:
+        filename = "downloaded_file"
+
+    local_path = target_dir / filename
+
+    logger.info(f"Downloading from URL: {url[:100]}... -> {local_path}")
+
+    try:
+        # User-Agent 헤더 추가 (일부 서버에서 필요)
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "Mozilla/5.0 (Proovy-AI/1.0)"}
+        )
+        with urllib.request.urlopen(req, timeout=60) as response:
+            with open(local_path, "wb") as f:
+                f.write(response.read())
+
+        logger.info(f"Download complete: {local_path}")
+        return local_path
+    except Exception as e:
+        logger.error(f"Failed to download from URL: {url}, error: {e}")
+        raise
 
 
 def get_local_image(ref: str) -> Path:


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #53 

## 🏷️ PR 타입
- [x] 🐛 버그 수정 (Bug Fix)


## 📝 작업 내용

- 전처리 utils.py 파일에 download_from_url 함수 추가 -> http/https 에서 파일 다운로드
- 그래프에 _is_http_url() 함수 추가, _localize_input_path() 함수로 http url도 다운로드 처리


## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다


## 📎 기타 참고사항

- s3 url 직접 찾아서 로컬에서 실험하기보다 배포에서 하는게 더 빠를 것 같아서 테스팅 없이 merge 하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **HTTP/HTTPS URL을 통한 원격 파일 다운로드 기능 추가** - 기존 S3 파일 지원 외에도 HTTP/HTTPS URL(공개 및 미리 서명된 URL 포함)에서 직접 파일을 다운로드하여 로컬 저장소에 자동으로 저장할 수 있습니다. 다양한 원격 소스 지원이 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->