### PR TITLE
[Fix] E2B sandbox 재사용 시 만료/종료 상태 자동 복구 로직 추가

### DIFF
--- a/src/agents/tools/e2b_runner.py
+++ b/src/agents/tools/e2b_runner.py
@@ -43,25 +43,47 @@ def _healthcheck_sandbox(sandbox: Sandbox) -> bool:
     return True
 
 
+def _dispose_sandbox(sandbox: Sandbox | None) -> None:
+    if sandbox is None:
+        return
+
+    # E2B SDK 버전에 따라 종료 메서드 명이 다를 수 있어 kill/close 순으로 시도한다.
+    for method_name in ("kill", "close"):
+        method = getattr(sandbox, method_name, None)
+        if callable(method):
+            try:
+                method()
+                return
+            except Exception:
+                continue
+
+
 def _reset_reused_sandbox() -> None:
     global _SANDBOX, _SANDBOX_LAST_USED_AT
+    sandbox_to_dispose: Sandbox | None = None
     with _SANDBOX_LOCK:
+        sandbox_to_dispose = _SANDBOX
         _SANDBOX = None
         _SANDBOX_LAST_USED_AT = None
+    _dispose_sandbox(sandbox_to_dispose)
 
 
 def _get_sandbox(api_key: str, *, reuse: bool) -> Sandbox:
     global _SANDBOX, _SANDBOX_LAST_USED_AT
     if not reuse:
         return Sandbox.create(api_key=api_key)
+    stale_sandbox: Sandbox | None = None
     with _SANDBOX_LOCK:
         if _SANDBOX is not None and _is_sandbox_stale() and not _healthcheck_sandbox(_SANDBOX):
+            stale_sandbox = _SANDBOX
             _SANDBOX = None
             _SANDBOX_LAST_USED_AT = None
 
         if _SANDBOX is None:
             _SANDBOX = Sandbox.create(api_key=api_key)
-        return _SANDBOX
+        sandbox = _SANDBOX
+    _dispose_sandbox(stale_sandbox)
+    return sandbox
 
 
 class E2BExecutionError(RuntimeError):

--- a/src/agents/tools/e2b_runner.py
+++ b/src/agents/tools/e2b_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -11,7 +12,7 @@ from e2b_code_interpreter.models import Execution
 from core.settings import settings
 
 _SANDBOX: Sandbox | None = None
-_SANDBOX_LOCK = None
+_SANDBOX_LOCK = threading.Lock()
 _SANDBOX_LAST_USED_AT: float | None = None
 
 _SANDBOX_MAX_IDLE_SECONDS = float(os.getenv("E2B_SANDBOX_MAX_IDLE_SECONDS", "240"))
@@ -29,21 +30,6 @@ def _is_sandbox_stale() -> bool:
     return (time.monotonic() - _SANDBOX_LAST_USED_AT) >= _SANDBOX_MAX_IDLE_SECONDS
 
 
-def _is_recoverable_sandbox_error(error_message: str) -> bool:
-    lowered = error_message.lower()
-    recoverable_tokens = (
-        "unexpectedendofexecution",
-        "sandbox",
-        "closed",
-        "terminated",
-        "timeout",
-        "connection",
-        "network",
-        "eof",
-    )
-    return any(token in lowered for token in recoverable_tokens)
-
-
 def _healthcheck_sandbox(sandbox: Sandbox) -> bool:
     try:
         sandbox.run_code(
@@ -58,27 +44,16 @@ def _healthcheck_sandbox(sandbox: Sandbox) -> bool:
 
 
 def _reset_reused_sandbox() -> None:
-    global _SANDBOX, _SANDBOX_LAST_USED_AT, _SANDBOX_LOCK
-    if _SANDBOX_LOCK is None:
-        import threading
-
-        _SANDBOX_LOCK = threading.Lock()
-
+    global _SANDBOX, _SANDBOX_LAST_USED_AT
     with _SANDBOX_LOCK:
         _SANDBOX = None
         _SANDBOX_LAST_USED_AT = None
 
 
 def _get_sandbox(api_key: str, *, reuse: bool) -> Sandbox:
-    global _SANDBOX, _SANDBOX_LOCK, _SANDBOX_LAST_USED_AT
+    global _SANDBOX, _SANDBOX_LAST_USED_AT
     if not reuse:
-        sandbox = Sandbox.create(api_key=api_key)
-        _mark_sandbox_used()
-        return sandbox
-    if _SANDBOX_LOCK is None:
-        import threading
-
-        _SANDBOX_LOCK = threading.Lock()
+        return Sandbox.create(api_key=api_key)
     with _SANDBOX_LOCK:
         if _SANDBOX is not None and _is_sandbox_stale() and not _healthcheck_sandbox(_SANDBOX):
             _SANDBOX = None
@@ -86,7 +61,6 @@ def _get_sandbox(api_key: str, *, reuse: bool) -> Sandbox:
 
         if _SANDBOX is None:
             _SANDBOX = Sandbox.create(api_key=api_key)
-        _mark_sandbox_used()
         return _SANDBOX
 
 
@@ -145,7 +119,8 @@ def run_python_with_e2b(
             timeout=timeout,
             request_timeout=request_timeout,
         )
-        _mark_sandbox_used()
+        if reuse_sandbox:
+            _mark_sandbox_used()
         return execution
 
     try:
@@ -167,8 +142,6 @@ def run_python_with_e2b(
 
     if execution.error:
         error_message = f"{execution.error.name}: {execution.error.value}"
-        if reuse_sandbox and _is_recoverable_sandbox_error(error_message):
-            _reset_reused_sandbox()
         raise E2BExecutionError(error_message, execution=execution)
 
     return E2BExecutionResult(

--- a/src/agents/tools/e2b_runner.py
+++ b/src/agents/tools/e2b_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -11,19 +12,81 @@ from core.settings import settings
 
 _SANDBOX: Sandbox | None = None
 _SANDBOX_LOCK = None
+_SANDBOX_LAST_USED_AT: float | None = None
+
+_SANDBOX_MAX_IDLE_SECONDS = float(os.getenv("E2B_SANDBOX_MAX_IDLE_SECONDS", "240"))
+_SANDBOX_HEALTHCHECK_TIMEOUT = float(os.getenv("E2B_SANDBOX_HEALTHCHECK_TIMEOUT", "5"))
+
+
+def _mark_sandbox_used() -> None:
+    global _SANDBOX_LAST_USED_AT
+    _SANDBOX_LAST_USED_AT = time.monotonic()
+
+
+def _is_sandbox_stale() -> bool:
+    if _SANDBOX_LAST_USED_AT is None:
+        return True
+    return (time.monotonic() - _SANDBOX_LAST_USED_AT) >= _SANDBOX_MAX_IDLE_SECONDS
+
+
+def _is_recoverable_sandbox_error(error_message: str) -> bool:
+    lowered = error_message.lower()
+    recoverable_tokens = (
+        "unexpectedendofexecution",
+        "sandbox",
+        "closed",
+        "terminated",
+        "timeout",
+        "connection",
+        "network",
+        "eof",
+    )
+    return any(token in lowered for token in recoverable_tokens)
+
+
+def _healthcheck_sandbox(sandbox: Sandbox) -> bool:
+    try:
+        sandbox.run_code(
+            "print('ok')",
+            language="python",
+            timeout=_SANDBOX_HEALTHCHECK_TIMEOUT,
+            request_timeout=_SANDBOX_HEALTHCHECK_TIMEOUT + 2,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def _reset_reused_sandbox() -> None:
+    global _SANDBOX, _SANDBOX_LAST_USED_AT, _SANDBOX_LOCK
+    if _SANDBOX_LOCK is None:
+        import threading
+
+        _SANDBOX_LOCK = threading.Lock()
+
+    with _SANDBOX_LOCK:
+        _SANDBOX = None
+        _SANDBOX_LAST_USED_AT = None
 
 
 def _get_sandbox(api_key: str, *, reuse: bool) -> Sandbox:
-    global _SANDBOX, _SANDBOX_LOCK
+    global _SANDBOX, _SANDBOX_LOCK, _SANDBOX_LAST_USED_AT
     if not reuse:
-        return Sandbox.create(api_key=api_key)
+        sandbox = Sandbox.create(api_key=api_key)
+        _mark_sandbox_used()
+        return sandbox
     if _SANDBOX_LOCK is None:
         import threading
 
         _SANDBOX_LOCK = threading.Lock()
     with _SANDBOX_LOCK:
+        if _SANDBOX is not None and _is_sandbox_stale() and not _healthcheck_sandbox(_SANDBOX):
+            _SANDBOX = None
+            _SANDBOX_LAST_USED_AT = None
+
         if _SANDBOX is None:
             _SANDBOX = Sandbox.create(api_key=api_key)
+        _mark_sandbox_used()
         return _SANDBOX
 
 
@@ -74,8 +137,7 @@ def run_python_with_e2b(
 
     api_key = _resolve_api_key()
 
-    try:
-        sandbox = _get_sandbox(api_key, reuse=reuse_sandbox)
+    def _execute(sandbox: Sandbox) -> Execution:
         execution = sandbox.run_code(
             code,
             language="python",
@@ -83,11 +145,30 @@ def run_python_with_e2b(
             timeout=timeout,
             request_timeout=request_timeout,
         )
+        _mark_sandbox_used()
+        return execution
+
+    try:
+        sandbox = _get_sandbox(api_key, reuse=reuse_sandbox)
+        execution = _execute(sandbox)
     except Exception as exc:
-        raise E2BExecutionError("Failed to execute code inside E2B sandbox.") from exc
+        if not reuse_sandbox:
+            raise E2BExecutionError("Failed to execute code inside E2B sandbox.") from exc
+
+        # 재사용 샌드박스가 만료/종료되었을 수 있으므로 한 번만 새로 만들어 재시도한다.
+        _reset_reused_sandbox()
+        try:
+            sandbox = _get_sandbox(api_key, reuse=True)
+            execution = _execute(sandbox)
+        except Exception as retry_exc:
+            raise E2BExecutionError(
+                "Failed to execute code inside E2B sandbox."
+            ) from retry_exc
 
     if execution.error:
         error_message = f"{execution.error.name}: {execution.error.value}"
+        if reuse_sandbox and _is_recoverable_sandbox_error(error_message):
+            _reset_reused_sandbox()
         raise E2BExecutionError(error_message, execution=execution)
 
     return E2BExecutionResult(


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #69 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- E2B sandbox 재사용 시 유휴시간 추적(`_SANDBOX_LAST_USED_AT`) 추가
- 유휴 시간이 길 경우 재사용 전 health-check 수행
  - `run_code("print('ok')")`로 생존 확인
  - 실패 시 기존 sandbox 폐기 후 신규 생성
- `reuse_sandbox=True` 실행 예외 발생 시
  - 전역 sandbox 리셋 후 1회 자동 재시도
- 종료/연결 계열 에러 메시지 감지 시 sandbox 즉시 폐기
- 환경변수 튜닝값 추가
  - `E2B_SANDBOX_MAX_IDLE_SECONDS` (default: 240)
  - `E2B_SANDBOX_HEALTHCHECK_TIMEOUT` (default: 5)

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 샌드박스 자동 모니터링으로 코드 실행 안정성 개선(상태 검사 및 헬스체크 추가)
  * 장시간 미사용 샌드박스 감지 후 자동 리셋 및 재생성 처리 추가
  * 샌드박스 재사용 시 사용 시각 기록 기능 추가로 유휴 타임아웃 적용
  * 실행 오류 발생 시 한 번의 자동 재시도 및 실패 시 안전한 오류 보고 처리 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->