### PR TITLE
[Fix] final response가 token 스트리밍을 하도록 변경

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -245,7 +245,9 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
     kwargs, run_id, _thread_id = await _handle_input(user_input, agent)
 
     try:
-        response_events: list[tuple[str, Any]] = await agent.ainvoke(**kwargs, stream_mode=["updates", "values"])
+        response_events: list[tuple[str, Any]] = await agent.ainvoke(
+            **kwargs, stream_mode=["updates", "values"]
+        )
         response_type, response = response_events[-1]
         if response_type == "values":
             output = langchain_to_chat_message(response["messages"][-1])
@@ -326,7 +328,7 @@ async def message_generator(
         progress = ChatMessage(
             type="custom",
             content="",
-            custom_data={"node": node_name, "status": message}
+            custom_data={"node": node_name, "status": message},
         )
         progress.run_id = str(run_id)
 
@@ -384,7 +386,10 @@ async def message_generator(
                                 feature_name = path_str.split("/")[0]
                         except Exception:
                             pass
-                    if feature_name in feature_nodes and feature_name not in credit_usage["used_features"]:
+                    if (
+                        feature_name in feature_nodes
+                        and feature_name not in credit_usage["used_features"]
+                    ):
                         credit_usage["used_features"].append(feature_name)
                         logger.info(f"Feature executed: {feature_name}")
 
@@ -409,8 +414,10 @@ async def message_generator(
                         else:
                             update_messages = []
 
-                    if node_name == "FinalResponse" and update_messages:
-                        new_messages.extend(update_messages)
+                    # FinalResponse 노드의 메시지는 토큰 스트리밍(stream_mode="messages")으로
+                    # 이미 전송되므로, updates 이벤트에서 중복 전송하지 않음
+                    # if node_name == "FinalResponse" and update_messages:
+                    #     new_messages.extend(update_messages)
 
             if stream_mode == "custom":
                 new_messages = [event]
@@ -438,7 +445,10 @@ async def message_generator(
                     logger.error(f"Error parsing message: {e}")
                     yield f"data: {json.dumps({'type': 'error', 'content': 'Unexpected error'}, ensure_ascii=False)}\n\n"
                     continue
-                if chat_message.type == "human" and chat_message.content == user_input.message:
+                if (
+                    chat_message.type == "human"
+                    and chat_message.content == user_input.message
+                ):
                     continue
                 yield f"data: {json.dumps({'type': 'message', 'content': chat_message.model_dump()}, ensure_ascii=False)}\n\n"
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -414,10 +414,12 @@ async def message_generator(
                         else:
                             update_messages = []
 
-                    # FinalResponse 노드의 메시지는 토큰 스트리밍(stream_mode="messages")으로
-                    # 이미 전송되므로, updates 이벤트에서 중복 전송하지 않음
-                    # if node_name == "FinalResponse" and update_messages:
-                    #     new_messages.extend(update_messages)
+                    # FinalResponse 노드의 메시지 전송:
+                    # - stream_tokens=True일 때: 토큰 스트리밍(messages)으로 이미 전송되므로 건너뜀
+                    # - stream_tokens=False일 때: updates에서 최종 응답을 전송해야 함
+                    if node_name == "FinalResponse" and update_messages:
+                        if not user_input.stream_tokens:
+                            new_messages.extend(update_messages)
 
             if stream_mode == "custom":
                 new_messages = [event]


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #71 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- final response 노드가 토큰 스트리밍을 하도록 재변경

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스트리밍 모드에서 중복된 최종 응답 전송을 방지하도록 동작을 조정했습니다(스트리밍 토큰 사용 시 최종 응답 미전송).
* **리팩토링**
  * 코드 가독성 향상을 위한 포맷팅 및 구조 정리를 진행했습니다.
  * 조건문 및 호출문 표현을 명확하게 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->