### PR TITLE
[Feat] FinalResponse를 재생성 대신 2~3문장 요약으로 축소

### DIFF
--- a/src/agents/workflows/final_response.py
+++ b/src/agents/workflows/final_response.py
@@ -109,11 +109,8 @@ def final_response(state: AgentState) -> AgentState:
         suggestion_bullets = final_output.get("suggestion_bullets")
 
         user_text = _last_user_message(state) or ""
-        conversation_context = get_conversation_summary(state, max_chars=1500)
 
         prompt_parts: list[str] = []
-        if conversation_context:
-            prompt_parts.append(f"[이전 대화 기록]\n{conversation_context}")
         if user_text:
             prompt_parts.append(f"[사용자 질문]\n{user_text}")
         if feature_sections:
@@ -127,15 +124,17 @@ def final_response(state: AgentState) -> AgentState:
             prompt_parts.append(f"[다음 학습 제안 요약]\n{suggestion_summary}")
 
         prompt_parts.append(
-            "위 정보를 바탕으로 사용자에게 보여줄 최종 한국어 답변을 작성해 줘. "
-            "핵심 풀이를 간결하게 정리하고, 마지막에는 '다음 학습 제안' 섹션을 반드시 포함해 줘. "
-            "수식은 필요할 때만 간단한 LaTeX로 표기해도 좋아."
+            "위 Writer 응답은 이미 사용자에게 스트리밍되었어. "
+            "지금은 **짧은 요약**(2~3문장)만 작성해 줘. "
+            "핵심 결론/정답만 간결하게 정리하고, "
+            "마지막에 '다음 학습 제안' 항목을 붙여 줘. "
+            "절대 위 응답을 다시 반복하지 마."
         )
 
         system_prompt = (
             "너는 수학·과학·프로그래밍 문제를 도와주는 한국어 튜터야. "
-            "주어진 부분 응답들을 중복 없이 자연스럽게 통합하고, "
-            "사용자가 다음에 무엇을 공부하면 좋은지 명확히 안내해 줘."
+            "이미 상세 설명은 사용자에게 전달되었으므로, "
+            "핵심 결론만 2~3문장으로 짧게 요약해 줘. 장황하게 쓰지 마."
         )
         user_prompt = "\n\n".join(prompt_parts)
         answer_text = call_model(


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #75 

## 🏷️ PR 타입

- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- FinalResponse( partial_responses 경로 ) 프롬프트를 요약 전용으로 변경
  - Writer 응답은 이미 스트리밍되었음을 명시
  - 2~3문장 짧은 요약 + '다음 학습 제안'만 생성하도록 제한
  - “절대 위 응답 반복 금지” 지시 추가
- 시스템 프롬프트도 요약/간결 지시로 축소
- 요약 경로에서 conversation_context 제거
  - LLM 입력 토큰 감소 → 응답 시작 시간 단축 기대

## 📸 스크린샷


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 최종 응답에서 이전 대화 내용이 반복되는 문제를 해결했습니다.
  * 응답이 이제 핵심 내용 2-3문장의 간결한 요약으로 제공되어 더 정확하고 효율적합니다.
  * 학습 제안 섹션은 여전히 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->