### PR TITLE
[Fix] Open api key에서 openrouter api key 사용하는 코드로 수정

### DIFF
--- a/src/rag/embeddings.py
+++ b/src/rag/embeddings.py
@@ -6,28 +6,34 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-# OpenAI 클라이언트 (lazy initialization)
+# OpenAI 클라이언트 (OpenRouter 호환, lazy initialization)
 _openai_client: Optional["OpenAI"] = None
 
 
 def _get_openai_client() -> "OpenAI":
-    """OpenAI 클라이언트를 lazy하게 초기화하여 반환."""
+    """OpenAI 호환 클라이언트를 lazy하게 초기화하여 반환.
+
+    OpenRouter 엔드포인트를 사용하여 임베딩을 생성합니다.
+    """
     global _openai_client
     if _openai_client is None:
         try:
             from openai import OpenAI
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
                 "openai package is required. Install with: pip install openai"
-            )
+            ) from err
 
-        api_key = os.getenv("OPENAI_API_KEY")
+        api_key = os.getenv("OPENROUTER_API_KEY")
         if not api_key:
             raise ValueError(
-                "OPENAI_API_KEY environment variable is required for embeddings"
+                "OPENROUTER_API_KEY environment variable is required for embeddings"
             )
 
-        _openai_client = OpenAI(api_key=api_key)
+        _openai_client = OpenAI(
+            api_key=api_key,
+            base_url="https://openrouter.ai/api/v1",
+        )
     return _openai_client
 
 
@@ -37,11 +43,11 @@ def embed_texts(
     model: Optional[str] = None,
     batch_size: Optional[int] = None,
 ) -> List[List[float]]:
-    """OpenAI Embeddings API를 사용하여 텍스트를 벡터로 변환.
+    """OpenRouter Embeddings API를 사용하여 텍스트를 벡터로 변환.
 
     Args:
         texts: 임베딩할 텍스트 리스트
-        model: 임베딩 모델명 (기본값: EMBEDDING_MODEL 환경변수 또는 text-embedding-3-small)
+        model: 임베딩 모델명 (기본값: EMBEDDING_MODEL 환경변수 또는 openai/text-embedding-3-small)
         batch_size: 배치 크기 (기본값: EMBEDDING_BATCH_SIZE 환경변수 또는 100)
 
     Returns:
@@ -56,7 +62,7 @@ def embed_texts(
 
     # 환경변수에서 설정 로드
     if model is None:
-        model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+        model = os.getenv("EMBEDDING_MODEL", "openai/text-embedding-3-small")
     if batch_size is None:
         batch_size = int(os.getenv("EMBEDDING_BATCH_SIZE", "100"))
 


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #84 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

src/rag/embeddings.py 파일 수정
  - base_url="https://openrouter.ai/api/v1" 설정
  - OPENROUTER_API_KEY 환경변수 사용
  - 기본 모델: openai/text-embedding-3-small

_openai_client = OpenAI(
      api_key=os.getenv("OPENROUTER_API_KEY"),
      base_url="https://openrouter.ai/api/v1",
  )으로 수정했다. 

## 📸 스크린샷


## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

