### PR TITLE
[Feat] SSE 스트리밍 프로토콜 v2 도입 (`/stream/v2`) 및 `astream_events` 기반 리팩토링

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,19 @@ Proovy-ai/
 ├── langgraph.json                # LangGraph Studio 설정
 ├── pyproject.toml                # uv 패키지 관리 설정
 ├── README.md
+├── SSE_PROTOCOL_V2.md            # SSE v2 프로토콜 명세
 └── uv.lock
 ```
 
 ### PDF 생성 엔진 (E2B)
 
 해설 PDF 생성 기능은 [E2B Code Interpreter](https://e2b.dev/) 보안 샌드박스 내에서 동적으로 Python 코드를 실행하여 처리됩니다. LaTeX 수식 렌더링 및 차트 생성을 위해 외부 샌드박스 환경을 활용합니다.
+
+### 스트리밍 프로토콜
+
+- `POST /stream`, `POST /{agent_id}/stream`: 기존 SSE(v1) 하위호환
+- `POST /stream/v2`, `POST /{agent_id}/stream/v2`: event 중심 SSE(v2)
+- v2 상세 명세: `SSE_PROTOCOL_V2.md`
 
 ### 워크플로우 시각화 (LangGraph Studio)
 

--- a/SSE_PROTOCOL_V2.md
+++ b/SSE_PROTOCOL_V2.md
@@ -1,0 +1,179 @@
+# SSE Protocol v2
+
+## 목적
+`/stream`(v1)의 `data.type` 중심 스트림을 유지하면서, `/stream/v2`에서 SSE 표준 `event` 기반으로 이벤트 의미를 명확히 분리합니다.
+
+- v1: 하위호환 유지
+- v2: `id/event/data` + 공통 envelope + terminal event 표준화
+
+## 구현 기준
+현재 v2 구현은 LangGraph `astream_events(..., version="v2")` 기반입니다.
+
+- 내부 런타임 이벤트(`on_chain_*`, `on_chat_model_*`, `on_tool_*`)를
+  서비스 이벤트 taxonomy로 매핑해 전송합니다.
+- v2에서는 `[DONE]` 문자열을 사용하지 않습니다.
+
+## 엔드포인트
+- `POST /stream` (v1, 유지)
+- `POST /{agent_id}/stream` (v1, 유지)
+- `POST /stream/v2` (v2)
+- `POST /{agent_id}/stream/v2` (v2)
+
+요청 바디는 `StreamInput`과 동일합니다.
+
+예시:
+
+```json
+{
+  "message": "안녕하세요",
+  "streamTokens": true,
+  "threadId": "test-thread-001",
+  "userId": "test-user-001"
+}
+```
+
+## SSE Frame 형식
+
+```text
+id: <run_id>:<seq>
+event: <event_name>
+data: <json>
+```
+
+- `id`: `<run_id>:<seq>`
+- `event`: taxonomy 이름
+- `data`: 공통 envelope + 이벤트 payload
+
+## 공통 Envelope
+모든 `data` JSON은 아래 공통 필드를 포함합니다.
+
+```json
+{
+  "v": "2.0",
+  "ts": "2026-02-17T14:30:00.000Z",
+  "seq": 1,
+  "run_id": "uuid",
+  "thread_id": "uuid"
+}
+```
+
+## 이벤트 taxonomy (현재 구현)
+
+### 세션/런
+- `session.metadata`
+  - payload: `agent_id`, `capabilities`
+- `run.started`
+  - payload: `stream_tokens`
+- `run.completed`
+  - payload: `duration_ms`, `final_message_id?`
+- `run.failed`
+  - payload: `code`, `message`, `retryable`
+
+terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
+
+### 노드
+- `node.started`
+  - payload: `node`, `node_path`
+- `node.progress`
+  - payload: `node`, `message`
+- `node.completed`
+  - payload: `node`, `status`, `duration_ms`
+
+매핑 기준:
+- `on_chain_start` -> `node.started` / `node.progress`
+- `on_chain_end` -> `node.completed`
+
+### LLM
+- `llm.message.started`
+  - payload: `message_id`, `node`, `role`
+- `llm.token.delta`
+  - payload: `message_id`, `node`, `delta`, `index`
+- `llm.message.completed`
+  - payload: `message_id`, `finish_reason`
+
+매핑 기준:
+- `on_chat_model_start` -> `llm.message.started`
+- `on_chat_model_stream` -> `llm.token.delta`
+- `on_chat_model_end` -> `llm.message.completed`
+
+### 메시지/툴/부가 이벤트
+- `chat.message`
+  - payload: `message_id`, `role`, `kind`, `content`, `node?`
+- `tool.call.started`
+  - payload: `tool_call_id`, `tool_name`
+- `tool.call.completed`
+  - payload: `tool_call_id`, `status`, `duration_ms`
+- `credit.updated`
+  - payload: `balance`, `total_cost`, `remaining`
+- `artifact.ready`
+  - payload: `artifact_id`, `name`, `mime`, `path`, `size`
+- `heartbeat`
+  - payload: `alive`
+
+`artifact.ready`는 현재 `final_output.solution.pdf_path`가 관측될 때 emit합니다.
+
+## `chat.message.kind` 표준값
+- `status`
+- `assistant_partial`
+- `assistant_final`
+- `tool_result`
+- `review`
+- `suggestion`
+- `system_notice`
+
+서버 매핑 요약:
+- `ai + node=FinalResponse` -> `assistant_final`
+- 일반 `ai` -> `assistant_partial`
+- `tool` -> `tool_result`
+- `custom + status 포함` -> `status`
+- `custom + node=Review` -> `review`
+- `custom + node=Suggestion` -> `suggestion`
+- 그 외 -> `system_notice`
+
+## 토큰 스트리밍 규칙
+- `stream_tokens=true`: `llm.token.delta` 전송
+- `stream_tokens=false`: `llm.token.delta` 미전송, 완결 `chat.message` 중심 전송
+
+## 순서 보장/주의사항
+- `seq`는 서버 전송 순서를 단조 증가로 보장합니다.
+- `astream_events` 기반이라 `on_chain_start`가 먼저 관측되면 `node.started`가 토큰보다 먼저 옵니다.
+- 다만 병렬 실행 노드가 있으면 서로 다른 노드 이벤트는 interleave될 수 있습니다.
+  클라이언트는 `event + node + message_id + seq` 기준으로 처리해야 합니다.
+
+## message_id 규칙
+- `m_llm_<n>`: LLM 토큰 스트림 단위 식별자
+- `m_chat_<n>`: 완결 `chat.message` 식별자
+- `m_interrupt_<n>`, `m_error_<n>`: 인터럽트/에러 메시지 식별자
+
+`message_id`는 run 범위 내 correlation id입니다.
+
+## 예시
+연결 직후:
+
+```text
+id: 8d1f...:1
+event: session.metadata
+data: {"v":"2.0","ts":"2026-02-17T14:30:00.000Z","seq":1,"run_id":"8d1f...","thread_id":"a21c...","agent_id":"tutor","capabilities":{"token_stream":true,"heartbeat":true,"terminal_event":true}}
+```
+
+토큰:
+
+```text
+id: 8d1f...:12
+event: llm.token.delta
+data: {"v":"2.0","ts":"2026-02-17T14:30:01.120Z","seq":12,"run_id":"8d1f...","thread_id":"a21c...","message_id":"m_llm_2","node":"FinalResponse","delta":"안","index":0}
+```
+
+종료:
+
+```text
+id: 8d1f...:45
+event: run.completed
+data: {"v":"2.0","ts":"2026-02-17T14:30:08.234Z","seq":45,"run_id":"8d1f...","thread_id":"a21c...","duration_ms":8234,"final_message_id":"m_chat_3"}
+```
+
+## 마이그레이션 가이드
+1. 프론트는 `/stream/v2`로 opt-in 전환합니다.
+2. `event` 기준 핸들러로 분기하고, `seq`를 기준으로 UI 상태를 반영합니다.
+3. 운영 안정화 후 v1 deprecate 공지를 진행합니다.
+4. 최종적으로 v1 제거를 검토합니다.

--- a/src/run_stream_client.py
+++ b/src/run_stream_client.py
@@ -6,6 +6,7 @@ CLI에서 /stream 엔드포인트를 호출해 SSE 응답을 관찰하고,
     uv run src/run_stream_client.py "2차 함수 개념 설명해줘"
     uv run src/run_stream_client.py --base-url http://localhost:8081 \
         --agent-id default "테스트"
+    uv run src/run_stream_client.py --protocol v2 "테스트"
 
 서버는 src/run_service.py 로 띄워져 있어야 한다.
 """
@@ -15,7 +16,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-from typing import Any
+from typing import Any, AsyncIterator
 
 import httpx
 
@@ -50,7 +51,45 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="받은 모든 SSE data payload(JSON)를 순서대로 출력",
     )
+    parser.add_argument(
+        "--protocol",
+        choices=["v1", "v2"],
+        default="v1",
+        help="SSE 프로토콜 버전 선택 (기본: v1)",
+    )
     return parser
+
+
+async def _iter_sse_frames(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:
+    event_name: str | None = None
+    event_id: str | None = None
+    data_lines: list[str] = []
+
+    async for line in response.aiter_lines():
+        if not line:
+            if data_lines:
+                yield {
+                    "id": event_id,
+                    "event": event_name,
+                    "data": "\n".join(data_lines),
+                }
+                event_name = None
+                event_id = None
+                data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("id:"):
+            event_id = line[len("id:") :].strip()
+            continue
+        if line.startswith("event:"):
+            event_name = line[len("event:") :].strip()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[len("data:") :].lstrip())
+
+    if data_lines:
+        yield {"id": event_id, "event": event_name, "data": "\n".join(data_lines)}
 
 
 async def _run_stream_client(args: argparse.Namespace) -> None:
@@ -70,10 +109,11 @@ async def _run_stream_client(args: argparse.Namespace) -> None:
     }
 
     base_url = args.base_url.rstrip("/")
+    stream_path = "/stream/v2" if args.protocol == "v2" else "/stream"
     if args.agent_id:
-        url = f"{base_url}/{args.agent_id}/stream"
+        url = f"{base_url}/{args.agent_id}{stream_path}"
     else:
-        url = f"{base_url}/stream"
+        url = f"{base_url}{stream_path}"
 
     print(f"\n[요청] POST {url}")
     print(f"payload: {json.dumps(payload, ensure_ascii=False)}\n")
@@ -89,20 +129,14 @@ async def _run_stream_client(args: argparse.Namespace) -> None:
             response.raise_for_status()
 
             full_token_text = ""
-            events: list[dict[str, Any]] = []
             message_events: list[dict[str, Any]] = []
 
-            async for line in response.aiter_lines():
-                if not line:
-                    continue
-                if not line.startswith("data: "):
-                    # SSE의 다른 필드(id:, event: 등)는 지금은 무시
+            async for frame in _iter_sse_frames(response):
+                data_str = str(frame.get("data") or "")
+                if not data_str:
                     continue
 
-                data_str = line[len("data: ") :].strip()
-
-                if data_str == "[DONE]":
-                    # 서버에서 스트림 종료를 알림
+                if args.protocol == "v1" and data_str == "[DONE]":
                     break
 
                 try:
@@ -111,31 +145,40 @@ async def _run_stream_client(args: argparse.Namespace) -> None:
                     print(f"[경고] JSON 파싱 불가 data: {data_str}")
                     continue
 
-                if isinstance(payload_obj, dict):
-                    events.append(payload_obj)
-                else:
-                    # dict 가 아닌 경우는 디버깅용으로만 출력
-                    events.append({"_raw": payload_obj})
+                if args.protocol == "v1":
+                    if args.show_events:
+                        print("[event]", json.dumps(payload_obj, ensure_ascii=False))
+                    if not isinstance(payload_obj, dict):
+                        continue
+                    event_type = payload_obj.get("type")
+                    if event_type == "token":
+                        full_token_text += payload_obj.get("content") or ""
+                    elif event_type == "message":
+                        message_events.append(payload_obj.get("content") or {})
+                    elif event_type == "error":
+                        print("[서버 에러]", payload_obj.get("content"))
+                    continue
 
+                event_name = frame.get("event") or ""
                 if args.show_events:
-                    print("[event]", json.dumps(payload_obj, ensure_ascii=False))
+                    print(
+                        "[event]",
+                        event_name,
+                        json.dumps(payload_obj, ensure_ascii=False),
+                    )
 
                 if not isinstance(payload_obj, dict):
                     continue
 
-                event_type = payload_obj.get("type")
-
-                if event_type == "token":
-                    # 토큰 스트림: content 문자열을 순서대로 이어붙인다.
-                    token_text = payload_obj.get("content") or ""
-                    full_token_text += token_text
-
-                elif event_type == "message":
-                    # ChatMessage 스키마(dict)를 그대로 보관
-                    message_events.append(payload_obj.get("content") or {})
-
-                elif event_type == "error":
-                    print("[서버 에러]", payload_obj.get("content"))
+                if event_name == "llm.token.delta":
+                    full_token_text += str(payload_obj.get("delta") or "")
+                elif event_name == "chat.message":
+                    message_events.append(payload_obj)
+                elif event_name == "run.failed":
+                    print("[서버 에러]", payload_obj.get("message"))
+                    break
+                elif event_name == "run.completed":
+                    break
 
     # 4) 요약 출력
     print("\n===== 토큰 스트림으로 재구성한 최종 응답 =====\n")
@@ -145,12 +188,18 @@ async def _run_stream_client(args: argparse.Namespace) -> None:
         print("(토큰 스트림이 없거나 비어 있습니다)")
 
     if message_events:
-        print("\n===== 마지막 message 이벤트 (ChatMessage) =====\n")
+        print("\n===== 마지막 message 이벤트 =====\n")
         last_msg = message_events[-1]
-        # ChatMessage(content=..., type=..., tool_calls=...) 구조를 가정
-        content = last_msg.get("content")
-        msg_type = last_msg.get("type")
-        print(f"type: {msg_type}")
+        if args.protocol == "v2":
+            content = last_msg.get("content")
+            role = last_msg.get("role")
+            kind = last_msg.get("kind")
+            print(f"role: {role}")
+            print(f"kind: {kind}")
+        else:
+            content = last_msg.get("content")
+            msg_type = last_msg.get("type")
+            print(f"type: {msg_type}")
         print("content:\n")
         print(content)
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -554,6 +554,9 @@ async def message_generator_v2(
         chat_message_count += 1
         return f"{prefix}_{chat_message_count}"
 
+    def sanitize_error_message(_: Exception) -> str:
+        return "Internal server error"
+
     def emit_chat_events(raw_message: Any, node_name: str | None) -> list[str]:
         nonlocal final_message_id
         events: list[str] = []
@@ -584,7 +587,9 @@ async def message_generator_v2(
             node_name=node_name,
             custom_data=chat_message.custom_data,
         )
-        signature = f"{chat_message.type}|{kind}|{node_name or ''}|{chat_message.content}"
+        signature = (
+            f"{chat_message.type}|{kind}|{node_name or ''}|{chat_message.content}"
+        )
         if signature in emitted_chat_signatures:
             return events
         emitted_chat_signatures.add(signature)
@@ -598,22 +603,29 @@ async def message_generator_v2(
             payload["node"] = node_name
         events.append(emitter.emit("chat.message", payload))
 
-        if chat_message.type == "tool":
-            events.append(
-                emitter.emit(
-                    "tool.call.completed",
-                    {
-                        "tool_call_id": chat_message.tool_call_id
-                        or next_message_id("tool_call"),
-                        "status": "success",
-                        "duration_ms": 0,
-                    },
-                )
-            )
-
         if kind == CHAT_MESSAGE_KIND_ASSISTANT_FINAL:
             final_message_id = message_id
         return events
+
+    def emit_interrupt_event(interrupt: Any, node_name: str | None) -> str | None:
+        nonlocal final_message_id
+        content = str(getattr(interrupt, "value", interrupt))
+        signature = f"interrupt|system_notice|{node_name or ''}|{content}"
+        if signature in emitted_chat_signatures:
+            return None
+        emitted_chat_signatures.add(signature)
+
+        message_id = next_message_id("m_interrupt")
+        final_message_id = message_id
+        payload: dict[str, Any] = {
+            "message_id": message_id,
+            "role": "assistant",
+            "kind": "system_notice",
+            "content": content,
+        }
+        if node_name:
+            payload["node"] = node_name
+        return emitter.emit("chat.message", payload)
 
     def _coerce_state_dict(value: Any) -> dict[str, Any]:
         if isinstance(value, dict):
@@ -638,7 +650,9 @@ async def message_generator_v2(
                 return normalized
         return None
 
-    def _node_path_from_event(stream_event: dict[str, Any], node_name: str | None) -> str:
+    def _node_path_from_event(
+        stream_event: dict[str, Any], node_name: str | None
+    ) -> str:
         metadata = stream_event.get("metadata")
         metadata_dict = metadata if isinstance(metadata, dict) else {}
         raw_path = metadata_dict.get("langgraph_path") or metadata_dict.get("node_path")
@@ -681,7 +695,9 @@ async def message_generator_v2(
                 return text
         return ""
 
-    def _events_from_state_like(state_like: dict[str, Any], node_name: str | None) -> list[str]:
+    def _events_from_state_like(
+        state_like: dict[str, Any], node_name: str | None
+    ) -> list[str]:
         nonlocal last_credit_signature
         lines: list[str] = []
         credit_state = state_like.get("credit_state")
@@ -696,7 +712,9 @@ async def message_generator_v2(
                 balance = credit_state.get("balance", 0)
                 total_cost = credit_state.get("total_cost", 0)
                 remaining = 0
-                if isinstance(balance, (int, float)) and isinstance(total_cost, (int, float)):
+                if isinstance(balance, (int, float)) and isinstance(
+                    total_cost, (int, float)
+                ):
                     remaining = balance - total_cost
                 lines.append(
                     emitter.emit(
@@ -710,7 +728,9 @@ async def message_generator_v2(
                 )
 
         final_output = state_like.get("final_output")
-        solution_output = final_output.get("solution") if isinstance(final_output, dict) else None
+        solution_output = (
+            final_output.get("solution") if isinstance(final_output, dict) else None
+        )
         if isinstance(solution_output, dict):
             artifact_path = solution_output.get("pdf_path")
             if artifact_path:
@@ -722,8 +742,11 @@ async def message_generator_v2(
                             "artifact.ready",
                             {
                                 "artifact_id": artifact_id,
-                                "name": solution_output.get("pdf_file_name") or artifact_id,
-                                "mime": solution_output.get("pdf_mime_type", "application/pdf"),
+                                "name": solution_output.get("pdf_file_name")
+                                or artifact_id,
+                                "mime": solution_output.get(
+                                    "pdf_mime_type", "application/pdf"
+                                ),
                                 "path": artifact_path,
                                 "size": solution_output.get("pdf_file_size", 0),
                             },
@@ -745,8 +768,6 @@ async def message_generator_v2(
                 kwargs["input"],
                 kwargs["config"],
                 version="v2",
-                stream_mode=["updates", "messages", "custom"],
-                subgraphs=True,
             ):
                 await queue.put(("event", stream_event))
         except Exception as exc:
@@ -769,7 +790,9 @@ async def message_generator_v2(
                 },
             },
         )
-        yield emitter.emit("run.started", {"stream_tokens": bool(user_input.stream_tokens)})
+        yield emitter.emit(
+            "run.started", {"stream_tokens": bool(user_input.stream_tokens)}
+        )
 
         while True:
             try:
@@ -822,17 +845,9 @@ async def message_generator_v2(
                     if isinstance(state_patch.get("__interrupt__"), list):
                         interrupt: Interrupt
                         for interrupt in state_patch["__interrupt__"]:
-                            message_id = next_message_id("m_interrupt")
-                            final_message_id = message_id
-                            yield emitter.emit(
-                                "chat.message",
-                                {
-                                    "message_id": message_id,
-                                    "role": "assistant",
-                                    "kind": "system_notice",
-                                    "content": str(getattr(interrupt, "value", interrupt)),
-                                },
-                            )
+                            interrupt_event = emit_interrupt_event(interrupt, node_name)
+                            if interrupt_event:
+                                yield interrupt_event
                     for line in _events_from_state_like(state_patch, node_name):
                         yield line
                 continue
@@ -843,17 +858,9 @@ async def message_generator_v2(
                     if isinstance(state_output.get("__interrupt__"), list):
                         interrupt: Interrupt
                         for interrupt in state_output["__interrupt__"]:
-                            message_id = next_message_id("m_interrupt")
-                            final_message_id = message_id
-                            yield emitter.emit(
-                                "chat.message",
-                                {
-                                    "message_id": message_id,
-                                    "role": "assistant",
-                                    "kind": "system_notice",
-                                    "content": str(getattr(interrupt, "value", interrupt)),
-                                },
-                            )
+                            interrupt_event = emit_interrupt_event(interrupt, node_name)
+                            if interrupt_event:
+                                yield interrupt_event
                     for line in _events_from_state_like(state_output, node_name):
                         yield line
 
@@ -884,7 +891,9 @@ async def message_generator_v2(
                 continue
 
             if event_name == "on_tool_start":
-                tool_call_id = str(stream_event.get("run_id") or next_message_id("tool_call"))
+                tool_call_id = str(
+                    stream_event.get("run_id") or next_message_id("tool_call")
+                )
                 tool_started_at[tool_call_id] = monotonic()
                 tool_name = str(stream_event.get("name") or "tool")
                 yield emitter.emit(
@@ -894,7 +903,9 @@ async def message_generator_v2(
                 continue
 
             if event_name == "on_tool_end":
-                tool_call_id = str(stream_event.get("run_id") or next_message_id("tool_call"))
+                tool_call_id = str(
+                    stream_event.get("run_id") or next_message_id("tool_call")
+                )
                 started_at = tool_started_at.pop(tool_call_id, monotonic())
                 duration_ms = max(0, int((monotonic() - started_at) * 1000))
                 yield emitter.emit(
@@ -1035,7 +1046,7 @@ async def message_generator_v2(
                 "run.failed",
                 {
                     "code": "internal_error",
-                    "message": str(e) or "Internal server error",
+                    "message": sanitize_error_message(e),
                     "retryable": False,
                 },
             )
@@ -1123,10 +1134,10 @@ def _sse_v2_response_example() -> dict[int | str, Any]:
                     "example": (
                         "id: 8d1f:1\n"
                         "event: session.metadata\n"
-                        "data: {\"v\":\"2.0\",\"seq\":1,\"run_id\":\"8d1f\",\"thread_id\":\"a21c\"}\n\n"
+                        'data: {"v":"2.0","seq":1,"run_id":"8d1f","thread_id":"a21c"}\n\n'
                         "id: 8d1f:2\n"
                         "event: run.completed\n"
-                        "data: {\"v\":\"2.0\",\"seq\":2,\"run_id\":\"8d1f\",\"thread_id\":\"a21c\",\"duration_ms\":1200}\n\n"
+                        'data: {"v":"2.0","seq":2,"run_id":"8d1f","thread_id":"a21c","duration_ms":1200}\n\n'
                     ),
                     "schema": {"type": "string"},
                 }

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -7,12 +7,14 @@ FastAPI 서비스 엔트리포인트.
   SSE(text/event-stream) 형식으로 변환해 클라이언트에 반환한다.
 """
 
+import asyncio
 import inspect
 import json
 import logging
 import warnings
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from time import monotonic
 from typing import Annotated, Any
 from uuid import UUID, uuid4
 
@@ -55,6 +57,12 @@ from service.utils import (
     remove_tool_calls,
 )
 from service.credit_service import get_credit_service, normalize_auth_token
+from service.sse_v2 import (
+    CHAT_MESSAGE_KIND_ASSISTANT_FINAL,
+    SseV2Emitter,
+    chat_kind_from_message,
+    chat_role_from_type,
+)
 
 warnings.filterwarnings("ignore", category=LangChainBetaWarning)
 logger = logging.getLogger(__name__)
@@ -63,6 +71,62 @@ logger = logging.getLogger(__name__)
 # HTTP requests don't look like errors in the service logs.
 logging.getLogger("e2b.api").setLevel(logging.WARNING)
 logging.getLogger("e2b.api.client_sync").setLevel(logging.WARNING)
+
+
+PROGRESS_MESSAGES: dict[str, str] = {
+    "CheckType": "첨부된 파일 유형을 분석하고 있습니다.",
+    "FileConvert": "문서를 이미지로 변환하고 있습니다.",
+    "VisionLLM": "이미지에서 텍스트와 수식을 추출하고 있습니다.",
+    "Intent": "질문의 의도를 분석하고 있습니다.",
+    "Planner": "여러 단계의 학습 계획을 세우고 있습니다.",
+    "Executor": "계획된 단계를 실행할 준비를 하고 있습니다.",
+    "RetryCounter": "이전 시도가 충분했는지 확인하고 있습니다.",
+    "EmbeddingSearch": "관련 자료를 검색하고 있습니다.",
+    "RelevanceCheck": "검색된 자료의 관련성을 평가하고 있습니다.",
+    "RetrievedDocs": "검색된 자료를 컨텍스트에 주입하고 있습니다.",
+    "Solve_Analysis": "문제를 분석하고 필요한 정보를 정리하고 있습니다.",
+    "Solve_Strategy": "문제 풀이 전략과 코드를 생성하고 있습니다.",
+    "Solve_Computation": "파이썬 코드를 실제로 실행 중입니다.",
+    "Solve_Writer": "풀이 결과를 정리하여 답변을 작성하고 있습니다.",
+    "Explain": "질문 내용을 쉽게 설명할 방법을 정리하고 있습니다.",
+    "Explain_Writer": "개념 설명을 작성하고 있습니다.",
+    "CreateGraph": "문제 상황을 그래프로 시각화할 방법을 고민하고 있습니다.",
+    "Variant": "비슷한 유형의 변형 문제를 생성하고 있습니다.",
+    "Solution": "풀이 과정을 정리하고 있습니다.",
+    "Check": "답이 올바른지 검산하고 있습니다.",
+    "Review": "전체 풀이 결과를 자동으로 리뷰하고 있습니다.",
+    "Suggestion": "다음 학습 방향에 대한 제안을 준비하고 있습니다.",
+}
+STREAM_V2_HEARTBEAT_INTERVAL_SEC = 15.0
+
+
+def _normalize_node_name(node: Any) -> str:
+    return str(node).split("/")[-1]
+
+
+def _normalize_node_path(node_path: Any | None, node: Any) -> str:
+    if node_path is None:
+        return str(node)
+    if isinstance(node_path, (tuple, list)):
+        return "/".join(str(part) for part in node_path)
+    return str(node_path)
+
+
+def _coalesce_messages(new_messages: list[Any]) -> list[Any]:
+    processed_messages: list[Any] = []
+    current_message: dict[str, Any] = {}
+    for message in new_messages:
+        if isinstance(message, tuple):
+            key, value = message
+            current_message[key] = value
+            continue
+        if current_message:
+            processed_messages.append(_create_ai_message(current_message))
+            current_message = {}
+        processed_messages.append(message)
+    if current_message:
+        processed_messages.append(_create_ai_message(current_message))
+    return processed_messages
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -290,30 +354,7 @@ async def message_generator(
         "difficulty": "easy",
     }
 
-    progress_messages: dict[str, str] = {
-        "CheckType": "첨부된 파일 유형을 분석하고 있습니다.",
-        "FileConvert": "문서를 이미지로 변환하고 있습니다.",
-        "VisionLLM": "이미지에서 텍스트와 수식을 추출하고 있습니다.",
-        "Intent": "질문의 의도를 분석하고 있습니다.",
-        "Planner": "여러 단계의 학습 계획을 세우고 있습니다.",
-        "Executor": "계획된 단계를 실행할 준비를 하고 있습니다.",
-        "RetryCounter": "이전 시도가 충분했는지 확인하고 있습니다.",
-        "EmbeddingSearch": "관련 자료를 검색하고 있습니다.",
-        "RelevanceCheck": "검색된 자료의 관련성을 평가하고 있습니다.",
-        "RetrievedDocs": "검색된 자료를 컨텍스트에 주입하고 있습니다.",
-        "Solve_Analysis": "문제를 분석하고 필요한 정보를 정리하고 있습니다.",
-        "Solve_Strategy": "문제 풀이 전략과 코드를 생성하고 있습니다.",
-        "Solve_Computation": "파이썬 코드를 실제로 실행 중입니다.",
-        "Solve_Writer": "풀이 결과를 정리하여 답변을 작성하고 있습니다.",
-        "Explain": "질문 내용을 쉽게 설명할 방법을 정리하고 있습니다.",
-        "Explain_Writer": "개념 설명을 작성하고 있습니다.",
-        "CreateGraph": "문제 상황을 그래프로 시각화할 방법을 고민하고 있습니다.",
-        "Variant": "비슷한 유형의 변형 문제를 생성하고 있습니다.",
-        "Solution": "풀이 과정을 정리하고 있습니다.",
-        "Check": "답이 올바른지 검산하고 있습니다.",
-        "Review": "전체 풀이 결과를 자동으로 리뷰하고 있습니다.",
-        "Suggestion": "다음 학습 방향에 대한 제안을 준비하고 있습니다.",
-    }
+    progress_messages = PROGRESS_MESSAGES
     emitted_progress_nodes: set[str] = set()
 
     def emit_progress(node_name: str) -> str | None:
@@ -481,6 +522,548 @@ async def message_generator(
         yield "data: [DONE]\n\n"
 
 
+async def message_generator_v2(
+    user_input: StreamInput, agent_id: str = DEFAULT_AGENT
+) -> AsyncGenerator[str, None]:
+    """Generate an SSE v2 stream with event-oriented payloads."""
+    agent: AgentGraph = get_agent(agent_id)
+    kwargs, run_id_obj, thread_id = await _handle_input(user_input, agent)
+    run_id = str(run_id_obj)
+    emitter = SseV2Emitter(run_id=run_id, thread_id=thread_id)
+    run_started_at = monotonic()
+    heartbeat_interval_sec = STREAM_V2_HEARTBEAT_INTERVAL_SEC
+
+    emitted_progress_nodes: set[str] = set()
+    node_started_at: dict[str, float] = {}
+    node_completed: set[str] = set()
+    emitted_artifacts: set[str] = set()
+    last_credit_signature: tuple[Any, Any, Any] | None = None
+
+    chat_message_count = 0
+    llm_message_count = 0
+    active_llm_message_id: str | None = None
+    active_llm_node: str | None = None
+    active_llm_token_index = 0
+    final_message_id: str | None = None
+    terminal_emitted = False
+    emitted_chat_signatures: set[str] = set()
+    tool_started_at: dict[str, float] = {}
+
+    def next_message_id(prefix: str) -> str:
+        nonlocal chat_message_count
+        chat_message_count += 1
+        return f"{prefix}_{chat_message_count}"
+
+    def emit_chat_events(raw_message: Any, node_name: str | None) -> list[str]:
+        nonlocal final_message_id
+        events: list[str] = []
+        try:
+            chat_message = langchain_to_chat_message(raw_message)
+            chat_message.run_id = run_id
+        except Exception as e:
+            logger.error(f"Error parsing v2 chat message: {e}")
+            events.append(
+                emitter.emit(
+                    "chat.message",
+                    {
+                        "message_id": next_message_id("m_error"),
+                        "role": "system",
+                        "kind": "system_notice",
+                        "content": "Unexpected error",
+                    },
+                )
+            )
+            return events
+
+        if chat_message.type == "human" and chat_message.content == user_input.message:
+            return events
+
+        message_id = next_message_id("m_chat")
+        kind = chat_kind_from_message(
+            message_type=chat_message.type,
+            node_name=node_name,
+            custom_data=chat_message.custom_data,
+        )
+        signature = f"{chat_message.type}|{kind}|{node_name or ''}|{chat_message.content}"
+        if signature in emitted_chat_signatures:
+            return events
+        emitted_chat_signatures.add(signature)
+        payload: dict[str, Any] = {
+            "message_id": message_id,
+            "role": chat_role_from_type(chat_message.type),
+            "kind": kind,
+            "content": chat_message.content,
+        }
+        if node_name:
+            payload["node"] = node_name
+        events.append(emitter.emit("chat.message", payload))
+
+        if chat_message.type == "tool":
+            events.append(
+                emitter.emit(
+                    "tool.call.completed",
+                    {
+                        "tool_call_id": chat_message.tool_call_id
+                        or next_message_id("tool_call"),
+                        "status": "success",
+                        "duration_ms": 0,
+                    },
+                )
+            )
+
+        if kind == CHAT_MESSAGE_KIND_ASSISTANT_FINAL:
+            final_message_id = message_id
+        return events
+
+    def _coerce_state_dict(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        if hasattr(value, "model_dump"):
+            dumped = value.model_dump()
+            if isinstance(dumped, dict):
+                return dumped
+        return {}
+
+    def _node_name_from_event(stream_event: dict[str, Any]) -> str | None:
+        metadata = stream_event.get("metadata")
+        metadata_dict = metadata if isinstance(metadata, dict) else {}
+        node = metadata_dict.get("langgraph_node") or metadata_dict.get("node")
+        if node:
+            return _normalize_node_name(node)
+
+        name = stream_event.get("name")
+        if isinstance(name, str):
+            normalized = _normalize_node_name(name)
+            if normalized in PROGRESS_MESSAGES or normalized in {"FinalResponse"}:
+                return normalized
+        return None
+
+    def _node_path_from_event(stream_event: dict[str, Any], node_name: str | None) -> str:
+        metadata = stream_event.get("metadata")
+        metadata_dict = metadata if isinstance(metadata, dict) else {}
+        raw_path = metadata_dict.get("langgraph_path") or metadata_dict.get("node_path")
+        if isinstance(raw_path, (tuple, list)):
+            path = "/".join(str(item) for item in raw_path if str(item))
+            if path:
+                return path
+        elif isinstance(raw_path, str) and raw_path.strip():
+            return raw_path
+        return node_name or ""
+
+    def _extract_finish_reason(end_data: dict[str, Any]) -> str:
+        output = end_data.get("output")
+        response_metadata = getattr(output, "response_metadata", None)
+        if isinstance(response_metadata, dict):
+            finish_reason = response_metadata.get("finish_reason")
+            if finish_reason is not None:
+                return str(finish_reason)
+        return "stop"
+
+    def _extract_delta_from_chunk(chunk: Any) -> str:
+        if isinstance(chunk, AIMessageChunk):
+            content = remove_tool_calls(chunk.content)
+            if not content:
+                return ""
+            return convert_message_content_to_string(content)
+
+        content = getattr(chunk, "content", None)
+        if isinstance(content, (str, list)):
+            filtered = remove_tool_calls(content)
+            if not filtered:
+                return ""
+            return convert_message_content_to_string(filtered)
+
+        if isinstance(chunk, str):
+            return chunk
+        if isinstance(chunk, dict):
+            text = chunk.get("text")
+            if isinstance(text, str):
+                return text
+        return ""
+
+    def _events_from_state_like(state_like: dict[str, Any], node_name: str | None) -> list[str]:
+        nonlocal last_credit_signature
+        lines: list[str] = []
+        credit_state = state_like.get("credit_state")
+        if isinstance(credit_state, dict):
+            signature = (
+                credit_state.get("balance"),
+                credit_state.get("total_cost"),
+                credit_state.get("difficulty"),
+            )
+            if signature != last_credit_signature:
+                last_credit_signature = signature
+                balance = credit_state.get("balance", 0)
+                total_cost = credit_state.get("total_cost", 0)
+                remaining = 0
+                if isinstance(balance, (int, float)) and isinstance(total_cost, (int, float)):
+                    remaining = balance - total_cost
+                lines.append(
+                    emitter.emit(
+                        "credit.updated",
+                        {
+                            "balance": balance,
+                            "total_cost": total_cost,
+                            "remaining": remaining,
+                        },
+                    )
+                )
+
+        final_output = state_like.get("final_output")
+        solution_output = final_output.get("solution") if isinstance(final_output, dict) else None
+        if isinstance(solution_output, dict):
+            artifact_path = solution_output.get("pdf_path")
+            if artifact_path:
+                artifact_id = str(solution_output.get("pdf_file_name") or artifact_path)
+                if artifact_id not in emitted_artifacts:
+                    emitted_artifacts.add(artifact_id)
+                    lines.append(
+                        emitter.emit(
+                            "artifact.ready",
+                            {
+                                "artifact_id": artifact_id,
+                                "name": solution_output.get("pdf_file_name") or artifact_id,
+                                "mime": solution_output.get("pdf_mime_type", "application/pdf"),
+                                "path": artifact_path,
+                                "size": solution_output.get("pdf_file_size", 0),
+                            },
+                        )
+                    )
+
+        if node_name == "FinalResponse":
+            messages = state_like.get("messages")
+            if isinstance(messages, list) and messages:
+                final_candidate = messages[-1]
+                for sse_line in emit_chat_events(final_candidate, node_name):
+                    lines.append(sse_line)
+
+        return lines
+
+    async def _pump_stream(queue: asyncio.Queue[tuple[str, Any]]) -> None:
+        try:
+            async for stream_event in agent.astream_events(
+                kwargs["input"],
+                kwargs["config"],
+                version="v2",
+                stream_mode=["updates", "messages", "custom"],
+                subgraphs=True,
+            ):
+                await queue.put(("event", stream_event))
+        except Exception as exc:
+            await queue.put(("error", exc))
+        finally:
+            await queue.put(("done", None))
+
+    queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+    pump_task = asyncio.create_task(_pump_stream(queue))
+
+    try:
+        yield emitter.emit(
+            "session.metadata",
+            {
+                "agent_id": agent_id,
+                "capabilities": {
+                    "token_stream": True,
+                    "heartbeat": True,
+                    "terminal_event": True,
+                },
+            },
+        )
+        yield emitter.emit("run.started", {"stream_tokens": bool(user_input.stream_tokens)})
+
+        while True:
+            try:
+                item_type, item = await asyncio.wait_for(
+                    queue.get(), timeout=heartbeat_interval_sec
+                )
+            except asyncio.TimeoutError:
+                yield emitter.emit("heartbeat", {"alive": True})
+                continue
+
+            if item_type == "done":
+                break
+            if item_type == "error":
+                raise item
+
+            stream_event = item
+            if not isinstance(stream_event, dict):
+                continue
+
+            event_name = str(stream_event.get("event") or "")
+            data = stream_event.get("data")
+            data_dict = data if isinstance(data, dict) else {}
+            metadata = stream_event.get("metadata")
+            metadata_dict = metadata if isinstance(metadata, dict) else {}
+            tags = stream_event.get("tags")
+            tag_list = tags if isinstance(tags, list) else []
+
+            node_name = _node_name_from_event(stream_event)
+            node_path_str = _node_path_from_event(stream_event, node_name)
+
+            if event_name == "on_chain_start" and node_name:
+                if node_name not in node_started_at:
+                    node_started_at[node_name] = monotonic()
+                    yield emitter.emit(
+                        "node.started",
+                        {"node": node_name, "node_path": node_path_str},
+                    )
+                    progress = PROGRESS_MESSAGES.get(node_name)
+                    if progress and node_name not in emitted_progress_nodes:
+                        emitted_progress_nodes.add(node_name)
+                        yield emitter.emit(
+                            "node.progress",
+                            {"node": node_name, "message": progress},
+                        )
+                continue
+
+            if event_name == "on_chain_stream":
+                state_patch = _coerce_state_dict(data_dict.get("chunk"))
+                if state_patch:
+                    if isinstance(state_patch.get("__interrupt__"), list):
+                        interrupt: Interrupt
+                        for interrupt in state_patch["__interrupt__"]:
+                            message_id = next_message_id("m_interrupt")
+                            final_message_id = message_id
+                            yield emitter.emit(
+                                "chat.message",
+                                {
+                                    "message_id": message_id,
+                                    "role": "assistant",
+                                    "kind": "system_notice",
+                                    "content": str(getattr(interrupt, "value", interrupt)),
+                                },
+                            )
+                    for line in _events_from_state_like(state_patch, node_name):
+                        yield line
+                continue
+
+            if event_name == "on_chain_end" and node_name:
+                state_output = _coerce_state_dict(data_dict.get("output"))
+                if state_output:
+                    if isinstance(state_output.get("__interrupt__"), list):
+                        interrupt: Interrupt
+                        for interrupt in state_output["__interrupt__"]:
+                            message_id = next_message_id("m_interrupt")
+                            final_message_id = message_id
+                            yield emitter.emit(
+                                "chat.message",
+                                {
+                                    "message_id": message_id,
+                                    "role": "assistant",
+                                    "kind": "system_notice",
+                                    "content": str(getattr(interrupt, "value", interrupt)),
+                                },
+                            )
+                    for line in _events_from_state_like(state_output, node_name):
+                        yield line
+
+                if node_name not in node_completed:
+                    node_completed.add(node_name)
+                    started_at = node_started_at.get(node_name, monotonic())
+                    duration_ms = max(0, int((monotonic() - started_at) * 1000))
+                    yield emitter.emit(
+                        "node.completed",
+                        {
+                            "node": node_name,
+                            "status": "success",
+                            "duration_ms": duration_ms,
+                        },
+                    )
+                continue
+
+            if event_name == "on_custom_event":
+                custom_payload = stream_event.get("data")
+                if isinstance(custom_payload, dict):
+                    custom_message = ChatMessage(
+                        type="custom",
+                        content="",
+                        custom_data=custom_payload,
+                    )
+                    for line in emit_chat_events(custom_message, node_name):
+                        yield line
+                continue
+
+            if event_name == "on_tool_start":
+                tool_call_id = str(stream_event.get("run_id") or next_message_id("tool_call"))
+                tool_started_at[tool_call_id] = monotonic()
+                tool_name = str(stream_event.get("name") or "tool")
+                yield emitter.emit(
+                    "tool.call.started",
+                    {"tool_call_id": tool_call_id, "tool_name": tool_name},
+                )
+                continue
+
+            if event_name == "on_tool_end":
+                tool_call_id = str(stream_event.get("run_id") or next_message_id("tool_call"))
+                started_at = tool_started_at.pop(tool_call_id, monotonic())
+                duration_ms = max(0, int((monotonic() - started_at) * 1000))
+                yield emitter.emit(
+                    "tool.call.completed",
+                    {
+                        "tool_call_id": tool_call_id,
+                        "status": "success",
+                        "duration_ms": duration_ms,
+                    },
+                )
+                continue
+
+            if event_name == "on_chat_model_start":
+                if not user_input.stream_tokens:
+                    continue
+                if "skip_stream" in tag_list:
+                    continue
+
+                token_node = str(
+                    metadata_dict.get("langgraph_node")
+                    or metadata_dict.get("node")
+                    or node_name
+                    or active_llm_node
+                    or "unknown"
+                )
+
+                if token_node not in node_started_at:
+                    node_started_at[token_node] = monotonic()
+                    yield emitter.emit(
+                        "node.started",
+                        {"node": token_node, "node_path": token_node},
+                    )
+                    progress = PROGRESS_MESSAGES.get(token_node)
+                    if progress and token_node not in emitted_progress_nodes:
+                        emitted_progress_nodes.add(token_node)
+                        yield emitter.emit(
+                            "node.progress",
+                            {"node": token_node, "message": progress},
+                        )
+
+                if active_llm_message_id is not None:
+                    yield emitter.emit(
+                        "llm.message.completed",
+                        {
+                            "message_id": active_llm_message_id,
+                            "finish_reason": "switch",
+                        },
+                    )
+
+                llm_message_count += 1
+                active_llm_message_id = f"m_llm_{llm_message_count}"
+                active_llm_node = token_node
+                active_llm_token_index = 0
+                yield emitter.emit(
+                    "llm.message.started",
+                    {
+                        "message_id": active_llm_message_id,
+                        "node": token_node,
+                        "role": "assistant",
+                    },
+                )
+                continue
+
+            if event_name == "on_chat_model_stream":
+                if not user_input.stream_tokens:
+                    continue
+                if "skip_stream" in tag_list:
+                    continue
+
+                token_node = str(
+                    metadata_dict.get("langgraph_node")
+                    or metadata_dict.get("node")
+                    or active_llm_node
+                    or "unknown"
+                )
+                if active_llm_message_id is None:
+                    llm_message_count += 1
+                    active_llm_message_id = f"m_llm_{llm_message_count}"
+                    active_llm_node = token_node
+                    active_llm_token_index = 0
+                    yield emitter.emit(
+                        "llm.message.started",
+                        {
+                            "message_id": active_llm_message_id,
+                            "node": token_node,
+                            "role": "assistant",
+                        },
+                    )
+
+                delta = _extract_delta_from_chunk(data_dict.get("chunk"))
+                if not delta:
+                    continue
+
+                yield emitter.emit(
+                    "llm.token.delta",
+                    {
+                        "message_id": active_llm_message_id,
+                        "node": token_node,
+                        "delta": delta,
+                        "index": active_llm_token_index,
+                    },
+                )
+                active_llm_token_index += 1
+                continue
+
+            if event_name == "on_chat_model_end":
+                if not user_input.stream_tokens:
+                    continue
+                if "skip_stream" in tag_list:
+                    continue
+                if active_llm_message_id is not None:
+                    yield emitter.emit(
+                        "llm.message.completed",
+                        {
+                            "message_id": active_llm_message_id,
+                            "finish_reason": _extract_finish_reason(data_dict),
+                        },
+                    )
+                    active_llm_message_id = None
+                    active_llm_node = None
+                    active_llm_token_index = 0
+                continue
+
+    except Exception as e:
+        logger.exception("Error in message generator v2")
+        if active_llm_message_id is not None:
+            yield emitter.emit(
+                "llm.message.completed",
+                {
+                    "message_id": active_llm_message_id,
+                    "finish_reason": "error",
+                },
+            )
+            active_llm_message_id = None
+        if not terminal_emitted:
+            terminal_emitted = True
+            yield emitter.emit(
+                "run.failed",
+                {
+                    "code": "internal_error",
+                    "message": str(e) or "Internal server error",
+                    "retryable": False,
+                },
+            )
+    finally:
+        if not pump_task.done():
+            pump_task.cancel()
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
+
+        if not terminal_emitted:
+            if active_llm_message_id is not None:
+                yield emitter.emit(
+                    "llm.message.completed",
+                    {
+                        "message_id": active_llm_message_id,
+                        "finish_reason": "stop",
+                    },
+                )
+            terminal_emitted = True
+            duration_ms = int((monotonic() - run_started_at) * 1000)
+            payload: dict[str, Any] = {"duration_ms": duration_ms}
+            if final_message_id:
+                payload["final_message_id"] = final_message_id
+            yield emitter.emit("run.completed", payload)
+
+
 def _create_ai_message(parts: dict) -> AIMessage:
     sig = inspect.signature(AIMessage)
     valid_keys = set(sig.parameters)
@@ -527,6 +1110,52 @@ async def stream(
     """
     return StreamingResponse(
         message_generator(user_input, agent_id),
+        media_type="text/event-stream",
+    )
+
+
+def _sse_v2_response_example() -> dict[int | str, Any]:
+    return {
+        status.HTTP_200_OK: {
+            "description": "Server Sent Event Response (Protocol v2)",
+            "content": {
+                "text/event-stream": {
+                    "example": (
+                        "id: 8d1f:1\n"
+                        "event: session.metadata\n"
+                        "data: {\"v\":\"2.0\",\"seq\":1,\"run_id\":\"8d1f\",\"thread_id\":\"a21c\"}\n\n"
+                        "id: 8d1f:2\n"
+                        "event: run.completed\n"
+                        "data: {\"v\":\"2.0\",\"seq\":2,\"run_id\":\"8d1f\",\"thread_id\":\"a21c\",\"duration_ms\":1200}\n\n"
+                    ),
+                    "schema": {"type": "string"},
+                }
+            },
+        }
+    }
+
+
+@router.post(
+    "/{agent_id}/stream/v2",
+    response_class=StreamingResponse,
+    responses=_sse_v2_response_example(),
+    operation_id="stream_v2_with_agent_id",
+)
+@router.post(
+    "/stream/v2",
+    response_class=StreamingResponse,
+    responses=_sse_v2_response_example(),
+)
+async def stream_v2(
+    user_input: StreamInput, agent_id: str = DEFAULT_AGENT
+) -> StreamingResponse:
+    """Stream SSE protocol v2 events.
+
+    v2 keeps `/stream` untouched and introduces event-oriented semantics at
+    `/stream/v2` for explicit client-side state handling.
+    """
+    return StreamingResponse(
+        message_generator_v2(user_input, agent_id),
         media_type="text/event-stream",
     )
 
@@ -612,6 +1241,12 @@ app.include_router(router)
 # POST /{agent_id}/stream
 
 # 특정 agent_id 에이전트에 대해 위와 동일하게 SSE 스트리밍을 수행.
+# POST /stream/v2
+
+# v2 프로토콜(event/id/data + envelope) 기반 SSE 스트리밍.
+# POST /{agent_id}/stream/v2
+
+# 특정 agent_id 에이전트에 대해 v2 SSE 스트리밍 수행.
 # POST /feedback
 
 # LangSmith에 피드백(run_id, key, score, 추가 kwargs)을 기록하는 래퍼 엔드포인트.

--- a/src/service/sse_v2.py
+++ b/src/service/sse_v2.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 SSE_V2_VERSION = "2.0"
+SSE_V2_RESERVED_ENVELOPE_KEYS = {"v", "ts", "seq", "run_id", "thread_id"}
 
 CHAT_MESSAGE_KIND_STATUS = "status"
 CHAT_MESSAGE_KIND_ASSISTANT_PARTIAL = "assistant_partial"
@@ -53,7 +54,13 @@ class SseV2Emitter:
             "thread_id": self.thread_id,
         }
         if payload:
-            data.update(payload)
+            data.update(
+                {
+                    key: value
+                    for key, value in payload.items()
+                    if key not in SSE_V2_RESERVED_ENVELOPE_KEYS
+                }
+            )
         event_id = f"{self.run_id}:{self.seq}"
         return (
             f"id: {event_id}\n"
@@ -103,4 +110,3 @@ def chat_kind_from_message(
         return CHAT_MESSAGE_KIND_ASSISTANT_PARTIAL
 
     return CHAT_MESSAGE_KIND_SYSTEM_NOTICE
-

--- a/src/service/sse_v2.py
+++ b/src/service/sse_v2.py
@@ -1,0 +1,106 @@
+"""SSE v2 protocol helpers.
+
+This module centralizes:
+- envelope creation (v/ts/seq/run_id/thread_id)
+- SSE frame formatting (id/event/data)
+- chat.message role/kind mapping
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+SSE_V2_VERSION = "2.0"
+
+CHAT_MESSAGE_KIND_STATUS = "status"
+CHAT_MESSAGE_KIND_ASSISTANT_PARTIAL = "assistant_partial"
+CHAT_MESSAGE_KIND_ASSISTANT_FINAL = "assistant_final"
+CHAT_MESSAGE_KIND_TOOL_RESULT = "tool_result"
+CHAT_MESSAGE_KIND_REVIEW = "review"
+CHAT_MESSAGE_KIND_SUGGESTION = "suggestion"
+CHAT_MESSAGE_KIND_SYSTEM_NOTICE = "system_notice"
+
+
+def utc_now_iso() -> str:
+    """Return a UTC ISO8601 timestamp with milliseconds and trailing Z."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+@dataclass
+class SseV2Emitter:
+    """Formats protocol-compliant SSE v2 frames with a shared envelope."""
+
+    run_id: str
+    thread_id: str
+    seq: int = 0
+
+    def emit(self, event: str, payload: dict[str, Any] | None = None) -> str:
+        if not event or "\n" in event:
+            raise ValueError("event name must be a non-empty single line")
+        self.seq += 1
+        data: dict[str, Any] = {
+            "v": SSE_V2_VERSION,
+            "ts": utc_now_iso(),
+            "seq": self.seq,
+            "run_id": self.run_id,
+            "thread_id": self.thread_id,
+        }
+        if payload:
+            data.update(payload)
+        event_id = f"{self.run_id}:{self.seq}"
+        return (
+            f"id: {event_id}\n"
+            f"event: {event}\n"
+            f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+        )
+
+
+def chat_role_from_type(message_type: str) -> str:
+    if message_type == "human":
+        return "user"
+    if message_type == "ai":
+        return "assistant"
+    if message_type == "tool":
+        return "tool"
+    return "system"
+
+
+def chat_kind_from_message(
+    *,
+    message_type: str,
+    node_name: str | None = None,
+    custom_data: dict[str, Any] | None = None,
+) -> str:
+    node = (node_name or "").strip()
+    custom = custom_data or {}
+
+    if message_type == "tool":
+        return CHAT_MESSAGE_KIND_TOOL_RESULT
+
+    if message_type == "custom":
+        if "status" in custom:
+            return CHAT_MESSAGE_KIND_STATUS
+        if node == "Review":
+            return CHAT_MESSAGE_KIND_REVIEW
+        if node == "Suggestion":
+            return CHAT_MESSAGE_KIND_SUGGESTION
+        return CHAT_MESSAGE_KIND_SYSTEM_NOTICE
+
+    if message_type == "ai":
+        if node == "FinalResponse":
+            return CHAT_MESSAGE_KIND_ASSISTANT_FINAL
+        if node == "Review":
+            return CHAT_MESSAGE_KIND_REVIEW
+        if node == "Suggestion":
+            return CHAT_MESSAGE_KIND_SUGGESTION
+        return CHAT_MESSAGE_KIND_ASSISTANT_PARTIAL
+
+    return CHAT_MESSAGE_KIND_SYSTEM_NOTICE
+

--- a/tests/service/test_stream_v2.py
+++ b/tests/service/test_stream_v2.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, AIMessageChunk
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from schema import StreamInput
+from service import service as service_module
+
+
+class _FakeAgent:
+    def __init__(
+        self,
+        events_v1: list[Any] | None = None,
+        events_v2: list[dict[str, Any]] | None = None,
+        error: Exception | None = None,
+        delay_sec: float = 0.0,
+    ) -> None:
+        self._events_v1 = events_v1 or []
+        self._events_v2 = events_v2 or []
+        self._error = error
+        self._delay_sec = delay_sec
+
+    async def astream(self, **kwargs: Any):  # noqa: ANN003
+        for event in self._events_v1:
+            await asyncio.sleep(self._delay_sec)
+            yield event
+        if self._error is not None:
+            raise self._error
+
+    async def astream_events(self, *args: Any, **kwargs: Any):  # noqa: ANN003
+        for event in self._events_v2:
+            await asyncio.sleep(self._delay_sec)
+            yield event
+        if self._error is not None:
+            raise self._error
+
+
+async def _fake_handle_input(
+    user_input: StreamInput,  # noqa: ARG001
+    agent: Any,  # noqa: ANN401, ARG001
+) -> tuple[dict[str, Any], uuid.UUID, str]:
+    return {"input": {}, "config": {}}, uuid.UUID(
+        "00000000-0000-0000-0000-000000000111"
+    ), "thread-test"
+
+
+async def _collect_chunks(generator) -> list[str]:  # noqa: ANN001
+    chunks: list[str] = []
+    async for chunk in generator:
+        chunks.append(chunk)
+    return chunks
+
+
+def _patch_stream_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    events_v1: list[Any] | None = None,
+    events_v2: list[dict[str, Any]] | None = None,
+    error: Exception | None = None,
+    delay_sec: float = 0.0,
+) -> None:
+    fake_agent = _FakeAgent(
+        events_v1=events_v1,
+        events_v2=events_v2,
+        error=error,
+        delay_sec=delay_sec,
+    )
+    monkeypatch.setattr(service_module, "get_agent", lambda _agent_id: fake_agent)
+    monkeypatch.setattr(service_module, "_handle_input", _fake_handle_input)
+
+
+def _parse_v2_chunks(chunks: list[str]) -> list[dict[str, Any]]:
+    parsed: list[dict[str, Any]] = []
+    for chunk in chunks:
+        frame: dict[str, Any] = {}
+        for line in chunk.strip().splitlines():
+            if line.startswith("id:"):
+                frame["id"] = line[len("id:") :].strip()
+            elif line.startswith("event:"):
+                frame["event"] = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                frame["data"] = json.loads(line[len("data:") :].strip())
+        if frame:
+            parsed.append(frame)
+    return parsed
+
+
+def _parse_v1_data(chunk: str) -> str:
+    assert chunk.startswith("data: ")
+    return chunk[len("data: ") :].strip()
+
+
+@pytest.mark.asyncio
+async def test_stream_v2_event_order_and_terminal_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_v2 = [
+        {
+            "event": "on_chain_start",
+            "name": "Intent",
+            "metadata": {"langgraph_node": "Intent", "langgraph_path": "Main/Intent"},
+            "data": {"input": {}},
+        },
+        {
+            "event": "on_chain_end",
+            "name": "Intent",
+            "metadata": {"langgraph_node": "Intent", "langgraph_path": "Main/Intent"},
+            "data": {
+                "output": {
+                    "credit_state": {"balance": 100, "total_cost": 1, "difficulty": "easy"}
+                }
+            },
+        },
+        {
+            "event": "on_chain_start",
+            "name": "FinalResponse",
+            "metadata": {
+                "langgraph_node": "FinalResponse",
+                "langgraph_path": "Main/FinalResponse",
+            },
+            "data": {"input": {}},
+        },
+        {
+            "event": "on_chat_model_start",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "FinalResponse"},
+            "tags": [],
+            "data": {"input": {"messages": []}},
+        },
+        {
+            "event": "on_chat_model_stream",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "FinalResponse"},
+            "tags": [],
+            "data": {"chunk": AIMessageChunk(content="안")},
+        },
+        {
+            "event": "on_chat_model_end",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "FinalResponse"},
+            "tags": [],
+            "data": {
+                "output": AIMessage(
+                    content="안",
+                    response_metadata={"finish_reason": "stop"},
+                )
+            },
+        },
+        {
+            "event": "on_chain_end",
+            "name": "FinalResponse",
+            "metadata": {
+                "langgraph_node": "FinalResponse",
+                "langgraph_path": "Main/FinalResponse",
+            },
+            "data": {"output": {"messages": [AIMessage(content="안녕하세요")]}},
+        },
+    ]
+    _patch_stream_dependencies(monkeypatch, events_v2=events_v2)
+
+    user_input = StreamInput(message="테스트", stream_tokens=True)
+    chunks = await _collect_chunks(service_module.message_generator_v2(user_input))
+    parsed = _parse_v2_chunks(chunks)
+    names = [frame["event"] for frame in parsed]
+
+    assert names[0] == "session.metadata"
+    assert names[1] == "run.started"
+    assert "node.started" in names
+    assert "node.progress" in names
+    assert "llm.message.started" in names
+    assert "llm.token.delta" in names
+    assert "llm.message.completed" in names
+    assert names[-1] == "run.completed"
+
+    terminals = [name for name in names if name in {"run.completed", "run.failed"}]
+    assert terminals == ["run.completed"]
+
+    seqs = [int(frame["data"]["seq"]) for frame in parsed]
+    assert seqs == sorted(seqs)
+
+    final_node_started_seq = next(
+        frame["data"]["seq"]
+        for frame in parsed
+        if frame["event"] == "node.started"
+        and frame["data"].get("node") == "FinalResponse"
+    )
+    first_token_seq = next(
+        frame["data"]["seq"]
+        for frame in parsed
+        if frame["event"] == "llm.token.delta"
+    )
+    assert final_node_started_seq < first_token_seq
+
+
+@pytest.mark.asyncio
+async def test_stream_v2_disables_llm_token_delta_when_stream_tokens_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_v2 = [
+        {
+            "event": "on_chain_start",
+            "name": "FinalResponse",
+            "metadata": {
+                "langgraph_node": "FinalResponse",
+                "langgraph_path": "Main/FinalResponse",
+            },
+            "data": {"input": {}},
+        },
+        {
+            "event": "on_chat_model_stream",
+            "name": "ChatOpenAI",
+            "metadata": {"langgraph_node": "FinalResponse"},
+            "tags": [],
+            "data": {"chunk": AIMessageChunk(content="안")},
+        },
+        {
+            "event": "on_chain_end",
+            "name": "FinalResponse",
+            "metadata": {
+                "langgraph_node": "FinalResponse",
+                "langgraph_path": "Main/FinalResponse",
+            },
+            "data": {"output": {"messages": [AIMessage(content="최종 답변")]}},
+        },
+    ]
+    _patch_stream_dependencies(monkeypatch, events_v2=events_v2)
+
+    user_input = StreamInput(message="테스트", stream_tokens=False)
+    chunks = await _collect_chunks(service_module.message_generator_v2(user_input))
+    parsed = _parse_v2_chunks(chunks)
+    names = [frame["event"] for frame in parsed]
+
+    assert "llm.token.delta" not in names
+    assert "chat.message" in names
+
+    chat_payloads = [frame["data"] for frame in parsed if frame["event"] == "chat.message"]
+    assert any(payload.get("kind") == "assistant_final" for payload in chat_payloads)
+
+
+@pytest.mark.asyncio
+async def test_stream_v2_emits_heartbeat_on_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_v2 = [
+        {
+            "event": "on_chain_start",
+            "name": "Intent",
+            "metadata": {"langgraph_node": "Intent", "langgraph_path": "Main/Intent"},
+            "data": {"input": {}},
+        },
+    ]
+    monkeypatch.setattr(service_module, "STREAM_V2_HEARTBEAT_INTERVAL_SEC", 0.01)
+    _patch_stream_dependencies(monkeypatch, events_v2=events_v2, delay_sec=0.03)
+
+    user_input = StreamInput(message="테스트", stream_tokens=True)
+    chunks = await _collect_chunks(service_module.message_generator_v2(user_input))
+    parsed = _parse_v2_chunks(chunks)
+    names = [frame["event"] for frame in parsed]
+
+    assert "heartbeat" in names
+
+
+@pytest.mark.asyncio
+async def test_stream_v2_emits_single_run_failed_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events_v2 = [
+        {
+            "event": "on_chain_start",
+            "name": "Intent",
+            "metadata": {"langgraph_node": "Intent", "langgraph_path": "Main/Intent"},
+            "data": {"input": {}},
+        },
+    ]
+    _patch_stream_dependencies(
+        monkeypatch,
+        events_v2=events_v2,
+        error=RuntimeError("boom"),
+    )
+
+    user_input = StreamInput(message="테스트", stream_tokens=True)
+    chunks = await _collect_chunks(service_module.message_generator_v2(user_input))
+    parsed = _parse_v2_chunks(chunks)
+    names = [frame["event"] for frame in parsed]
+
+    terminals = [name for name in names if name in {"run.completed", "run.failed"}]
+    assert terminals == ["run.failed"]
+
+    failed_payload = next(
+        frame["data"] for frame in parsed if frame["event"] == "run.failed"
+    )
+    assert failed_payload["code"] == "internal_error"
+    assert failed_payload["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_v1_backward_compatibility(monkeypatch: pytest.MonkeyPatch) -> None:
+    events_v1 = [
+        (
+            "FinalResponse",
+            "messages",
+            (
+                AIMessageChunk(content="안"),
+                {"tags": []},
+            ),
+        ),
+    ]
+    _patch_stream_dependencies(monkeypatch, events_v1=events_v1)
+
+    user_input = StreamInput(message="테스트", stream_tokens=True)
+    chunks = await _collect_chunks(service_module.message_generator(user_input))
+
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+    payloads: list[dict[str, Any]] = []
+    for chunk in chunks[:-1]:
+        data = _parse_v1_data(chunk)
+        if data == "[DONE]":
+            continue
+        payloads.append(json.loads(data))
+
+    assert payloads[0]["type"] == "thread_id"
+    assert payloads[0]["thread_id"] == "thread-test"
+    assert any(payload.get("type") == "token" for payload in payloads)
+
+
+def test_stream_v2_routes_registered() -> None:
+    paths = {route.path for route in service_module.app.routes}
+    assert "/stream/v2" in paths
+    assert "/{agent_id}/stream/v2" in paths


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #88

## 배경
기존 `/stream`(v1)은 `data.type` 중심이라 이벤트 의미(진행/토큰/완료/에러)가 섞여 있었고, `astream(... stream_mode=["updates","messages","custom"])` 특성상 `node.started`가 토큰 뒤에 오는 순서 문제도 발생할 수 있었습니다.

## 변경 요약
- v1 하위호환을 유지한 채 `/stream/v2` 신규 추가
- v2를 `astream_events(version="v2")` 기반으로 리팩토링
- SSE 표준 `id/event/data` + 공통 envelope(`v/ts/seq/run_id/thread_id`) 적용
- terminal을 `[DONE]` 대신 `run.completed` / `run.failed`로 표준화
- heartbeat 이벤트 추가
- `streamTokens=false`일 때 `llm.token.delta` 미전송 보장
- CLI에 v2 모드 추가 (`--protocol v2`)
- 프로토콜 문서 및 테스트 추가

## 주요 변경사항

### 1) API/스트리밍
- 신규 엔드포인트
  - `POST /stream/v2`
  - `POST /{agent_id}/stream/v2`
- 파일: `src/service/service.py`

### 2) v2 emitter 유틸
- `id/event/data` 강제 포맷터 및 envelope 주입기 추가
- `chat.message.kind` 표준 매핑 유틸 추가
- 파일: `src/service/sse_v2.py`

### 3) v2 이벤트 처리 방식 전환
- 기존: `agent.astream(...)`
- 변경: `agent.astream_events(..., version="v2")`
- 효과: `on_chain_start` 기반으로 `node.started`를 먼저 emit 가능 (순서 안정화)

### 4) 이벤트 taxonomy 적용
- `session.metadata`
- `run.started`
- `node.started`, `node.progress`, `node.completed`
- `llm.message.started`, `llm.token.delta`, `llm.message.completed`
- `chat.message`
- `tool.call.started`, `tool.call.completed`
- `artifact.ready`
- `credit.updated`
- `heartbeat`
- `run.completed` / `run.failed`

### 5) CLI 개선
- `src/run_stream_client.py`
- `--protocol v1|v2` 옵션 추가
- v2 SSE frame(`id/event/data`) 파싱 지원

### 6) 문서
- `SSE_PROTOCOL_V2.md` 신규 작성
- README에 v2 엔드포인트/문서 링크 추가

### 7) 테스트
- `tests/service/test_stream_v2.py` 신규
- 검증 항목
  - 이벤트 순서 (FinalResponse `node.started`가 토큰보다 먼저)
  - terminal event 단일성
  - token on/off (`streamTokens`)
  - heartbeat
  - v1 하위호환 회귀
  - v2 라우트 등록

## 하위호환/영향 범위
- 기존 `/stream`(v1) 동작 유지 (`[DONE]` 포함)
- 스트리밍 영역 외 비즈니스 로직 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * SSE 프로토콜 v2 지원 추가 및 이벤트 중심 스트리밍 엔드포인트(/stream/v2) 제공
  * 클라이언트에서 v1/v2 프로토콜 선택 옵션 추가 및 프로토콜별 출력 처리 개선

* **문서화**
  * SSE_PROTOCOL_V2.md로 v2 스펙 상세 문서 추가
  * README에 스트리밍 프로토콜(종류 및 엔드포인트) 섹션 추가

* **테스트**
  * v2 동작, 이벤트 순서, 토큰 스트리밍 및 v1 호환성 검증을 위한 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->