### PR TITLE
[Feat] node.started/node.completed 이벤트에 VISIBLE_NODES 화이트리스트 적용

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -103,6 +103,22 @@ CHAT_MESSAGE_EMITTING_NODES: dict[str, str] = {
     "CreditInsufficient": "system_notice",
     "Fallback": "system_notice",
 }
+VISIBLE_NODES: set[str] = set(PROGRESS_MESSAGES.keys()) | {
+    "FinalResponse",
+    "Simple_response",
+    "Fallback",
+    "CreditInsufficient",
+    "CreditCheck",
+    "Router",
+    "Preprocessing",
+    "RAG",
+    "Solve",
+    "Explain",
+    "CreateGraph",
+    "Variant",
+    "Solution",
+    "Check",
+}
 STREAM_V2_HEARTBEAT_INTERVAL_SEC = 15.0
 
 
@@ -842,6 +858,8 @@ async def message_generator_v2(
             node_path_str = _node_path_from_event(stream_event, node_name)
 
             if event_name == "on_chain_start" and node_name:
+                if node_name not in VISIBLE_NODES:
+                    continue
                 if node_name not in node_started_at:
                     node_started_at[node_name] = monotonic()
                     yield emitter.emit(
@@ -882,6 +900,8 @@ async def message_generator_v2(
                     for line in _events_from_state_like(state_output, node_name):
                         yield line
 
+                if node_name not in VISIBLE_NODES:
+                    continue
                 if node_name not in node_completed:
                     node_completed.add(node_name)
                     started_at = node_started_at.get(node_name, monotonic())
@@ -950,7 +970,7 @@ async def message_generator_v2(
                     or "unknown"
                 )
 
-                if token_node not in node_started_at:
+                if token_node in VISIBLE_NODES and token_node not in node_started_at:
                     node_started_at[token_node] = monotonic()
                     yield emitter.emit(
                         "node.started",


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #94

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- node.started/node.completed에 VISIBLE_NODES 화이트리스트 적용
- on_chain_end에서 상태 이벤트 추출은 유지하고 완료 이벤트만 필터링
- 토큰 스트림 시작 시 node.started도 VISIBLE_NODES만 발행

## 📸 스크린샷

- 로컬 콘솔 확인 (스크린샷 생략)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 테스트는 추가하지 않았습니다.