### PR TITLE
[Refactor] emitted_chat_signatures 해시로 메모리 최적화

### DIFF
--- a/SSE_PROTOCOL_V2.md
+++ b/SSE_PROTOCOL_V2.md
@@ -9,9 +9,10 @@
 ## 구현 기준
 현재 v2 구현은 LangGraph `astream_events(..., version="v2")` 기반입니다.
 
-- 내부 런타임 이벤트(`on_chain_*`, `on_chat_model_*`, `on_tool_*`)를
+- 내부 런타임 이벤트(`on_chain_*`, `on_chat_model_*`, `on_tool_*`, `on_custom_event`)를
   서비스 이벤트 taxonomy로 매핑해 전송합니다.
-- v2에서는 `[DONE]` 문자열을 사용하지 않습니다.
+- v2에서는 `[DONE]` 문자열을 사용하지 않습니다. terminal event는 `run.completed` 또는 `run.failed` 중 하나입니다.
+- 모든 `data`는 UTF-8 JSON으로 전송되며(`ensure_ascii=False`), `v/ts/seq/run_id/thread_id` 키는 payload에서 무시됩니다.
 
 ## 엔드포인트
 - `POST /stream` (v1, 유지)
@@ -57,7 +58,44 @@ data: <json>
 }
 ```
 
+- `seq`는 SSE 프레임 단위로 1씩 증가합니다.
+- `id`는 `run_id:seq` 포맷이며 클라이언트 재연결을 위한 기준으로 사용할 수 있습니다.
+
 ## 이벤트 taxonomy (현재 구현)
+
+## 이벤트/데이터 형식 표
+
+### 세션/런
+| event | data 필드 | 설명 | 예시 payload |
+| --- | --- | --- | --- |
+| session.metadata | agent_id, capabilities | 연결 직후 1회 전송되는 세션 메타 | `{"agent_id":"tutor","capabilities":{"token_stream":true,"heartbeat":true,"terminal_event":true}}` |
+| run.started | stream_tokens | 스트림 시작(토큰 스트리밍 여부 포함) | `{"stream_tokens":true}` |
+| run.completed | duration_ms, final_message_id? | 정상 종료(terminal) | `{"duration_ms":8234,"final_message_id":"m_chat_3"}` |
+| run.failed | code, message, retryable | 실패 종료(terminal) | `{"code":"internal_error","message":"Internal server error","retryable":false}` |
+
+### 노드
+| event | data 필드 | 설명 | 예시 payload |
+| --- | --- | --- | --- |
+| node.started | node, node_path | 노드 시작(visible 노드만) | `{"node":"FinalResponse","node_path":"Main/FinalResponse"}` |
+| node.progress | node, message | 진행 메시지(1회) | `{"node":"Solve","message":"문제를 분석하고 필요한 정보를 정리하고 있습니다."}` |
+| node.completed | node, status, duration_ms | 노드 종료(현재 status=success) | `{"node":"FinalResponse","status":"success","duration_ms":1200}` |
+
+### LLM
+| event | data 필드 | 설명 | 예시 payload |
+| --- | --- | --- | --- |
+| llm.message.started | message_id, node, role | LLM 메시지 시작 | `{"message_id":"m_llm_2","node":"FinalResponse","role":"assistant"}` |
+| llm.token.delta | message_id, node, delta, index | 토큰 델타 스트림 | `{"message_id":"m_llm_2","node":"FinalResponse","delta":"안","index":0}` |
+| llm.message.completed | message_id, finish_reason | LLM 메시지 종료(stop/switch/error) | `{"message_id":"m_llm_2","finish_reason":"stop"}` |
+
+### 메시지/툴/부가
+| event | data 필드 | 설명 | 예시 payload |
+| --- | --- | --- | --- |
+| chat.message | message_id, role, kind, content, node? | 완결 메시지/커스텀/인터럽트 | `{"message_id":"m_chat_3","role":"assistant","kind":"assistant_final","content":"안녕하세요","node":"FinalResponse"}` |
+| tool.call.started | tool_call_id, tool_name | 툴 호출 시작 | `{"tool_call_id":"tool_call_1","tool_name":"calculator"}` |
+| tool.call.completed | tool_call_id, status, duration_ms | 툴 호출 종료(현재 status=success) | `{"tool_call_id":"tool_call_1","status":"success","duration_ms":230}` |
+| credit.updated | balance, total_cost, remaining | 크레딧 상태 변경 | `{"balance":100,"total_cost":1,"remaining":99}` |
+| artifact.ready | artifact_id, name, mime, path, size | 결과물 준비 완료 | `{"artifact_id":"solution.pdf","name":"solution.pdf","mime":"application/pdf","path":"/tmp/solution.pdf","size":102400}` |
+| heartbeat | alive | 유휴 상태 heartbeat | `{"alive":true}` |
 
 ### 세션/런
 - `session.metadata`
@@ -70,6 +108,12 @@ data: <json>
   - payload: `code`, `message`, `retryable`
 
 terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
+`final_message_id`는 `assistant_final` 또는 `interrupt` 계열 메시지가 emit된 경우에만 포함됩니다.
+
+런 시작/종료 흐름:
+- 연결 직후 `session.metadata` -> `run.started` 순으로 항상 1회씩 전송됩니다.
+- 에러 발생 시 `run.failed`가 전송되고, 정상 종료 시 `run.completed`가 전송됩니다.
+- 현재 구현에서 `run.failed.code=internal_error`, `retryable=false`로 고정됩니다.
 
 ### 노드
 - `node.started`
@@ -83,6 +127,23 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 - `on_chain_start` -> `node.started` / `node.progress`
 - `on_chain_end` -> `node.completed`
 
+추가 규칙:
+- `node.*`는 `VISIBLE_NODES`에 포함된 노드만 전송됩니다.
+- `node_path`는 `langgraph_path`/`node_path` 메타데이터에서 생성하며 없으면 `node`로 대체합니다.
+- LLM 토큰 이벤트가 먼저 들어오는 경우에도 `node.started`가 보정 전송될 수 있습니다.
+- 현재 `node.completed.status`는 `success`로 고정됩니다.
+
+`VISIBLE_NODES`:
+`FinalResponse`, `Simple_response`, `Fallback`, `CreditInsufficient`, `CreditCheck`,
+`Router`, `Preprocessing`, `RAG`, `Solve`, `Explain`, `CreateGraph`, `Variant`,
+`Solution`, `Check` 및 아래 `PROGRESS_MESSAGES` 목록
+
+`PROGRESS_MESSAGES` (node.progress 메시지 텍스트):
+`CheckType`, `FileConvert`, `VisionLLM`, `Intent`, `Planner`, `Executor`, `RetryCounter`,
+`EmbeddingSearch`, `RelevanceCheck`, `RetrievedDocs`, `Solve_Analysis`,
+`Solve_Strategy`, `Solve_Computation`, `Solve_Writer`, `Explain`, `Explain_Writer`,
+`CreateGraph`, `Variant`, `Solution`, `Check`, `Review`, `Suggestion`
+
 ### LLM
 - `llm.message.started`
   - payload: `message_id`, `node`, `role`
@@ -95,6 +156,13 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 - `on_chat_model_start` -> `llm.message.started`
 - `on_chat_model_stream` -> `llm.token.delta`
 - `on_chat_model_end` -> `llm.message.completed`
+
+추가 규칙:
+- `stream_tokens=false`면 `llm.*` 이벤트는 전송하지 않습니다.
+- `tags`에 `skip_stream`이 있으면 `llm.*` 이벤트는 전송하지 않습니다.
+- `on_chat_model_stream`이 먼저 도착하면 내부적으로 `llm.message.started`를 선행 발행합니다.
+- 새로운 LLM 메시지가 시작되는데 이전 LLM 메시지가 종료되지 않았다면
+  `llm.message.completed`(`finish_reason: "switch"`)가 먼저 전송됩니다.
 
 ### 메시지/툴/부가 이벤트
 - `chat.message`
@@ -110,7 +178,16 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 - `heartbeat`
   - payload: `alive`
 
-`artifact.ready`는 현재 `final_output.solution.pdf_path`가 관측될 때 emit합니다.
+추가 규칙:
+- `chat.message`는 동일 메시지 중복 전송을 막기 위해 `(type, kind, node, content_hash)` 기준으로 dedupe됩니다.
+- 사용자 입력과 동일한 `human` 메시지는 전송하지 않습니다.
+- `on_custom_event`는 `custom` 메시지로 변환하여 `chat.message`로 전송합니다.
+- `__interrupt__`가 state에서 관측되면 `chat.message(kind=system_notice)`로 전송됩니다.
+- `tool_call_id`는 `stream_event.run_id`가 있으면 사용하고, 없으면 내부 생성 id를 사용합니다.
+- 현재 `tool.call.completed.status`는 `success`로 고정됩니다.
+- `artifact.ready`는 `final_output.solution.pdf_path`가 관측될 때 emit합니다.
+- `credit.updated`는 `credit_state(balance, total_cost, difficulty)` 변경 시 emit합니다.
+- `heartbeat`는 스트림이 일정 시간(기본 15초) 동안 유휴일 때 emit합니다.
 
 ## `chat.message.kind` 표준값
 - `status`
@@ -123,6 +200,8 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 
 서버 매핑 요약:
 - `ai + node=FinalResponse` -> `assistant_final`
+- `ai + node=Review` -> `review`
+- `ai + node=Suggestion` -> `suggestion`
 - 일반 `ai` -> `assistant_partial`
 - `tool` -> `tool_result`
 - `custom + status 포함` -> `status`
@@ -140,10 +219,15 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 - 다만 병렬 실행 노드가 있으면 서로 다른 노드 이벤트는 interleave될 수 있습니다.
   클라이언트는 `event + node + message_id + seq` 기준으로 처리해야 합니다.
 
+LLM 스트림 관련 주의:
+- `llm.message.completed`는 `finish_reason`으로 `stop`, `switch`, `error`를 전달할 수 있습니다.
+- `llm.message.completed`는 `stream_tokens=true` 조건에서만 emit됩니다.
+
 ## message_id 규칙
 - `m_llm_<n>`: LLM 토큰 스트림 단위 식별자
 - `m_chat_<n>`: 완결 `chat.message` 식별자
 - `m_interrupt_<n>`, `m_error_<n>`: 인터럽트/에러 메시지 식별자
+- `tool_call_<n>`: tool 이벤트 fallback id
 
 `message_id`는 run 범위 내 correlation id입니다.
 

--- a/SSE_PROTOCOL_V2.md
+++ b/SSE_PROTOCOL_V2.md
@@ -66,6 +66,7 @@ data: <json>
 ## 이벤트/데이터 형식 표
 
 ### 세션/런
+
 | event | data 필드 | 설명 | 예시 payload |
 | --- | --- | --- | --- |
 | session.metadata | agent_id, capabilities | 연결 직후 1회 전송되는 세션 메타 | `{"agent_id":"tutor","capabilities":{"token_stream":true,"heartbeat":true,"terminal_event":true}}` |
@@ -73,29 +74,36 @@ data: <json>
 | run.completed | duration_ms, final_message_id? | 정상 종료(terminal) | `{"duration_ms":8234,"final_message_id":"m_chat_3"}` |
 | run.failed | code, message, retryable | 실패 종료(terminal) | `{"code":"internal_error","message":"Internal server error","retryable":false}` |
 
+
 ### 노드
+
 | event | data 필드 | 설명 | 예시 payload |
 | --- | --- | --- | --- |
 | node.started | node, node_path | 노드 시작(visible 노드만) | `{"node":"FinalResponse","node_path":"Main/FinalResponse"}` |
 | node.progress | node, message | 진행 메시지(1회) | `{"node":"Solve","message":"문제를 분석하고 필요한 정보를 정리하고 있습니다."}` |
 | node.completed | node, status, duration_ms | 노드 종료(현재 status=success) | `{"node":"FinalResponse","status":"success","duration_ms":1200}` |
 
+
 ### LLM
+
 | event | data 필드 | 설명 | 예시 payload |
 | --- | --- | --- | --- |
 | llm.message.started | message_id, node, role | LLM 메시지 시작 | `{"message_id":"m_llm_2","node":"FinalResponse","role":"assistant"}` |
 | llm.token.delta | message_id, node, delta, index | 토큰 델타 스트림 | `{"message_id":"m_llm_2","node":"FinalResponse","delta":"안","index":0}` |
 | llm.message.completed | message_id, finish_reason | LLM 메시지 종료(stop/switch/error) | `{"message_id":"m_llm_2","finish_reason":"stop"}` |
 
+
 ### 메시지/툴/부가
+
 | event | data 필드 | 설명 | 예시 payload |
 | --- | --- | --- | --- |
 | chat.message | message_id, role, kind, content, node? | 완결 메시지/커스텀/인터럽트 | `{"message_id":"m_chat_3","role":"assistant","kind":"assistant_final","content":"안녕하세요","node":"FinalResponse"}` |
 | tool.call.started | tool_call_id, tool_name | 툴 호출 시작 | `{"tool_call_id":"tool_call_1","tool_name":"calculator"}` |
 | tool.call.completed | tool_call_id, status, duration_ms | 툴 호출 종료(현재 status=success) | `{"tool_call_id":"tool_call_1","status":"success","duration_ms":230}` |
-| credit.updated | balance, total_cost, remaining | 크레딧 상태 변경 | `{"balance":100,"total_cost":1,"remaining":99}` |
+| credit.updated | balance, total_cost, remaining | 크레딧 상태 변경(remaining = balance - total_cost) | `{"balance":100,"total_cost":1,"remaining":99}` |
 | artifact.ready | artifact_id, name, mime, path, size | 결과물 준비 완료 | `{"artifact_id":"solution.pdf","name":"solution.pdf","mime":"application/pdf","path":"/tmp/solution.pdf","size":102400}` |
 | heartbeat | alive | 유휴 상태 heartbeat | `{"alive":true}` |
+
 
 ### 세션/런
 - `session.metadata`
@@ -186,7 +194,7 @@ terminal은 `run.completed` 또는 `run.failed` 중 정확히 1회입니다.
 - `tool_call_id`는 `stream_event.run_id`가 있으면 사용하고, 없으면 내부 생성 id를 사용합니다.
 - 현재 `tool.call.completed.status`는 `success`로 고정됩니다.
 - `artifact.ready`는 `final_output.solution.pdf_path`가 관측될 때 emit합니다.
-- `credit.updated`는 `credit_state(balance, total_cost, difficulty)` 변경 시 emit합니다.
+- `credit.updated`는 `credit_state(balance, total_cost, difficulty)` 변경 시 emit하며, payload에는 `difficulty`를 포함하지 않습니다.
 - `heartbeat`는 스트림이 일정 시간(기본 15초) 동안 유휴일 때 emit합니다.
 
 ## `chat.message.kind` 표준값

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -615,7 +615,9 @@ async def message_generator_v2(
             custom_data=chat_message.custom_data,
         )
         content_str = convert_message_content_to_string(chat_message.content)
-        content_hash = hashlib.md5(content_str.encode("utf-8")).hexdigest()[:16]
+        content_hash = hashlib.md5(
+            content_str.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()[:16]
         signature = f"{chat_message.type}|{kind}|{node_name or ''}|{content_hash}"
         if signature in emitted_chat_signatures:
             return events
@@ -637,7 +639,9 @@ async def message_generator_v2(
     def emit_interrupt_event(interrupt: Any, node_name: str | None) -> str | None:
         nonlocal final_message_id
         content = str(getattr(interrupt, "value", interrupt))
-        content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()[:16]
+        content_hash = hashlib.md5(
+            content.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()[:16]
         signature = f"interrupt|system_notice|{node_name or ''}|{content_hash}"
         if signature in emitted_chat_signatures:
             return None

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -8,6 +8,7 @@ FastAPI 서비스 엔트리포인트.
 """
 
 import asyncio
+import hashlib
 import inspect
 import json
 import logging
@@ -613,9 +614,9 @@ async def message_generator_v2(
             node_name=node_name,
             custom_data=chat_message.custom_data,
         )
-        signature = (
-            f"{chat_message.type}|{kind}|{node_name or ''}|{chat_message.content}"
-        )
+        content_str = convert_message_content_to_string(chat_message.content)
+        content_hash = hashlib.md5(content_str.encode("utf-8")).hexdigest()[:16]
+        signature = f"{chat_message.type}|{kind}|{node_name or ''}|{content_hash}"
         if signature in emitted_chat_signatures:
             return events
         emitted_chat_signatures.add(signature)
@@ -636,7 +637,8 @@ async def message_generator_v2(
     def emit_interrupt_event(interrupt: Any, node_name: str | None) -> str | None:
         nonlocal final_message_id
         content = str(getattr(interrupt, "value", interrupt))
-        signature = f"interrupt|system_notice|{node_name or ''}|{content}"
+        content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()[:16]
+        signature = f"interrupt|system_notice|{node_name or ''}|{content_hash}"
         if signature in emitted_chat_signatures:
             return None
         emitted_chat_signatures.add(signature)


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #95

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- chat.message 중복 방지 signature를 content 해시(MD5 16자) 기반으로 변경
- interrupt 이벤트 signature도 동일하게 해시 기반으로 변경

## 📸 스크린샷

- 없음 (텍스트 테스트 로그 확인)

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 테스트: `uv run --python 3.11 -m pytest -q tests/service/test_stream_v2.py`
- 로컬 환경에서 `pytest-asyncio` 설치 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * SSE v2 스트리밍 형식 도입: 새 이벤트 타입(세션/런/노드/LLM/채팅/툴 등), 순번(seq)/id 재연결 규칙, UTF-8 JSON 페이로드와 예시 및 마이그레이션 안내가 추가되었습니다.

* **버그 수정 및 개선**
  * 이벤트 서명에 콘텐츠 해시를 사용해 채팅·인터럽트 이벤트 중복 검출을 강화했습니다.
  * terminal 처리 및 일부 이벤트 상태(예: run.failed) 동작이 명확히 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->