### PR TITLE
[Fix] 사용자가 이전 대화를 참조할 때만 히스토리 포함

### DIFF
--- a/src/agents/workflows/final_response.py
+++ b/src/agents/workflows/final_response.py
@@ -20,7 +20,7 @@ from agents.prompts.final_response_prompts import (
     TRADITIONAL_RESPONSE_USER_INSTRUCTION,
 )
 from agents.state import AgentState
-from agents.workflows.utils import call_model, get_conversation_summary
+from agents.workflows.utils import call_model, get_conversation_summary, references_previous_conversation
 from schema.models import OpenRouterModelName
 
 
@@ -161,8 +161,11 @@ def final_response(state: AgentState) -> AgentState:
         # review_state는 JSON이 아닌 자연스러운 한국어 메시지로 변환
         formatted_review = _format_review_message(review_state)
 
-        # 이전 대화 맥락 수집 (멀티턴 대화 지원)
-        conversation_context = get_conversation_summary(state, max_chars=1500)
+        # 사용자가 이전 대화를 명시적으로 참조하는 경우에만 히스토리 포함
+        if references_previous_conversation(user_text):
+            conversation_context = get_conversation_summary(state, max_chars=1500, max_turns=2)
+        else:
+            conversation_context = ""
 
         system_prompt = TRADITIONAL_RESPONSE_SYSTEM_PROMPT
 

--- a/src/agents/workflows/maingraph.py
+++ b/src/agents/workflows/maingraph.py
@@ -200,7 +200,7 @@ def simple_response(state: AgentState) -> AgentState:
     checkpointer가 저장한 이전 대화 히스토리를 활용하여
     멀티턴 대화의 맥락을 유지합니다.
     """
-    from agents.workflows.utils import get_conversation_history, message_to_text
+    from agents.workflows.utils import get_conversation_history, message_to_text, references_previous_conversation
 
     print("---MAIN: SIMPLE RESPONSE---")
     messages = state.get("messages") or []
@@ -217,34 +217,34 @@ def simple_response(state: AgentState) -> AgentState:
     if not user_text:
         return state
 
-    # 이전 대화 히스토리를 LLM에 전달하기 위해 수집
-    # 최근 5턴의 대화를 포함하여 맥락 유지
-    conversation_history = get_conversation_history(
-        state,
-        max_turns=5,
-        max_chars_per_message=800,
-    )
+    # 사용자가 이전 대화를 명시적으로 참조하는 경우에만 히스토리 포함
+    uses_prev_ref = references_previous_conversation(user_text)
 
-    # 대화 맥락 요약 생성 (시스템 프롬프트에 포함)
     history_context = ""
-    if len(conversation_history) > 1:  # 이전 대화가 있는 경우
-        history_lines = []
-        for msg in conversation_history[:-1]:  # 마지막 메시지 제외 (현재 질문)
-            role = "사용자" if getattr(msg, "type", "") in {"human", "user"} else "AI"
-            content = message_to_text(msg)[:300]
-            history_lines.append(f"{role}: {content}")
-        if history_lines:
-            history_context = "\n\n[이전 대화 기록]\n" + "\n".join(history_lines)
+    conversation_history = []
+    if uses_prev_ref:
+        conversation_history = get_conversation_history(
+            state,
+            max_turns=3,
+            max_chars_per_message=800,
+        )
+        if len(conversation_history) > 1:
+            history_lines = []
+            for msg in conversation_history[:-1]:  # 마지막 메시지 제외 (현재 질문)
+                role = "사용자" if getattr(msg, "type", "") in {"human", "user"} else "AI"
+                content = message_to_text(msg)[:300]
+                history_lines.append(f"{role}: {content}")
+            if history_lines:
+                history_context = "\n\n[이전 대화 기록]\n" + "\n".join(history_lines)
 
     system_prompt = build_simple_response_system_prompt(history_context)
 
     model = get_model(OpenRouterModelName.GPT_5_MINI)
 
-    # 전체 대화 히스토리를 LLM에 전달
+    # 이전 대화 맥락이 있으면 메시지로 포함, 없으면 현재 질문만 전달
     prompt_messages = [SystemMessage(content=system_prompt)]
 
-    # 이전 대화 맥락이 있으면 메시지로 포함
-    if len(conversation_history) > 1:
+    if uses_prev_ref and len(conversation_history) > 1:
         prompt_messages.extend(conversation_history)
     else:
         prompt_messages.append(HumanMessage(content=user_text))

--- a/src/agents/workflows/utils.py
+++ b/src/agents/workflows/utils.py
@@ -110,12 +110,67 @@ def get_conversation_history(
     return result
 
 
-def get_conversation_summary(state: AgentState, *, max_chars: int = 2000) -> str:
+_PREV_REF_KEYWORDS = (
+    "이전",
+    "아까",
+    "방금",
+    "저번",
+    "전에",
+    "그 문제",
+    "그문제",
+    "앞에서",
+    "위에서",
+    "아까 푼",
+    "전 문제",
+    "전문제",
+    "먼저 푼",
+    "처음 문제",
+)
+
+
+def references_previous_conversation(text: str) -> bool:
+    """사용자 메시지가 이전 대화를 명시적으로 참조하는지 확인한다."""
+    return any(kw in text for kw in _PREV_REF_KEYWORDS)
+
+
+def get_conversation_summary(
+    state: AgentState,
+    *,
+    max_chars: int = 2000,
+    max_turns: int | None = None,
+) -> str:
     """대화 히스토리를 간략한 요약 문자열로 반환한다.
 
     시스템 프롬프트에 대화 맥락을 포함시킬 때 유용합니다.
+
+    Args:
+        state: 현재 AgentState
+        max_chars: 전체 요약의 최대 문자 수
+        max_turns: 포함할 최대 대화 턴 수 (None이면 제한 없음).
+                   현재 질문은 제외하고 이전 대화만 카운트합니다.
     """
     messages = state.get("messages") or []
+
+    # max_turns가 지정된 경우, 가장 최근 메시지부터 역순으로 수집 후 되돌림
+    if max_turns is not None:
+        selected: List[BaseMessage] = []
+        turns_collected = 0
+        last_type = None
+        for message in reversed(messages):
+            msg_type = getattr(message, "type", "")
+            if msg_type in {"system", "tool"}:
+                continue
+            if msg_type not in {"human", "user", "ai", "assistant"}:
+                continue
+            is_user = msg_type in {"human", "user"}
+            if last_type is not None and is_user and last_type in {"ai", "assistant"}:
+                turns_collected += 1
+            if turns_collected >= max_turns:
+                break
+            selected.append(message)
+            last_type = msg_type
+        messages = list(reversed(selected))
+
     summary_parts: List[str] = []
     total_chars = 0
 

--- a/src/agents/workflows/utils.py
+++ b/src/agents/workflows/utils.py
@@ -86,8 +86,10 @@ def get_conversation_history(
         if last_type is not None:
             if is_user and last_type in {"ai", "assistant"}:
                 turns_collected += 1
+                if turns_collected > max_turns:
+                    break
 
-        if turns_collected >= max_turns:
+        if turns_collected > max_turns:
             break
 
         # 메시지 텍스트 추출 및 truncate
@@ -107,15 +109,18 @@ def get_conversation_history(
         last_type = msg_type
 
     result.reverse()
+    # 턴 경계에서 잘린 orphan AIMessage는 API 입력 안정성을 위해 제거한다.
+    while result and getattr(result[0], "type", "") in {"ai", "assistant"}:
+        result = result[1:]
     return result
 
 
 _PREV_REF_KEYWORDS = (
-    "이전",
     "아까",
     "방금",
     "저번",
-    "전에",
+    "전에 풀었던",
+    "전에 나온",
     "그 문제",
     "그문제",
     "앞에서",
@@ -125,6 +130,9 @@ _PREV_REF_KEYWORDS = (
     "전문제",
     "먼저 푼",
     "처음 문제",
+    "이전 문제",
+    "이전 대화",
+    "이전에 풀었던",
 )
 
 
@@ -156,6 +164,17 @@ def get_conversation_summary(
         selected: List[BaseMessage] = []
         turns_collected = 0
         last_type = None
+        skip_latest_user = False
+
+        # 마지막 대화 메시지가 사용자라면(=현재 질문), max_turns 요약에서 제외한다.
+        for message in reversed(messages):
+            msg_type = getattr(message, "type", "")
+            if msg_type in {"human", "user"}:
+                skip_latest_user = True
+                break
+            if msg_type in {"ai", "assistant"}:
+                break
+
         for message in reversed(messages):
             msg_type = getattr(message, "type", "")
             if msg_type in {"system", "tool"}:
@@ -163,13 +182,25 @@ def get_conversation_summary(
             if msg_type not in {"human", "user", "ai", "assistant"}:
                 continue
             is_user = msg_type in {"human", "user"}
+
+            if is_user and skip_latest_user:
+                skip_latest_user = False
+                continue
+
             if last_type is not None and is_user and last_type in {"ai", "assistant"}:
                 turns_collected += 1
-            if turns_collected >= max_turns:
+                if turns_collected > max_turns:
+                    break
+            if turns_collected > max_turns:
                 break
+
             selected.append(message)
             last_type = msg_type
         messages = list(reversed(selected))
+
+    # 턴 경계에서 잘리면 AI로 시작할 수 있어, 선두 orphan AI를 제거한다.
+    while messages and getattr(messages[0], "type", "") in {"ai", "assistant"}:
+        messages = messages[1:]
 
     summary_parts: List[str] = []
     total_chars = 0

--- a/tests/conversation_utils_test.py
+++ b/tests/conversation_utils_test.py
@@ -1,0 +1,56 @@
+from langchain_core.messages import AIMessage, HumanMessage
+
+from agents.workflows.utils import (
+    get_conversation_history,
+    get_conversation_summary,
+    references_previous_conversation,
+)
+
+
+def _state_with_messages(messages):
+    return {"messages": messages}
+
+
+def test_references_previous_conversation_avoids_generic_false_positive():
+    assert not references_previous_conversation("이전 단원에서 배운 공식 알려줘")
+    assert not references_previous_conversation("전에 이런 유형 본 적 있어?")
+    assert references_previous_conversation("이전 대화에서 푼 문제 다시 설명해줘")
+    assert references_previous_conversation("전에 풀었던 문제 다시 보여줘")
+
+
+def test_get_conversation_summary_excludes_current_user_and_keeps_user_first():
+    messages = [
+        HumanMessage(content="h1"),
+        AIMessage(content="a1"),
+        HumanMessage(content="h2"),
+        AIMessage(content="a2"),
+        HumanMessage(content="current"),
+    ]
+    state = _state_with_messages(messages)
+
+    summary = get_conversation_summary(state, max_chars=2000, max_turns=2)
+    lines = summary.splitlines()
+
+    assert lines
+    assert lines[0].startswith("사용자:")
+    assert "current" not in summary
+    assert "h1" in summary
+    assert "a2" in summary
+
+
+def test_get_conversation_history_does_not_start_with_orphan_ai():
+    messages = [
+        HumanMessage(content="h1"),
+        AIMessage(content="a1"),
+        HumanMessage(content="h2"),
+        AIMessage(content="a2"),
+        HumanMessage(content="h3"),
+        AIMessage(content="a3"),
+        HumanMessage(content="h4"),
+    ]
+    state = _state_with_messages(messages)
+
+    history = get_conversation_history(state, max_turns=2, max_chars_per_message=2000)
+
+    assert [message.content for message in history] == ["h2", "a2", "h3", "a3", "h4"]
+    assert history[0].type in {"human", "user"}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #104 

## 🏷️ PR 타입
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용
- 사용자 메시지에 이전 대화를 참조하는 키워드가 있을 때만 이전 대화 히스토리를 포함하도록 수정
- `max_turns`를 사용하여 이전 대화의 범위를 제한
- `references_previous_conversation` 함수를 통해 사용자가 이전 대화를 참조하는지 확인
- `max_turns=2`로 설정하여 최근 2턴만 포함하도록 수정

## 📸 스크린샷


## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 테스트를 작성하고 모두 통과했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항
- 키워드 목록은 `_PREV_REF_KEYWORDS`에 추가되어 있으며, 필요 시 추가 수정 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 대화 이력 관리 최적화: 사용자가 이전 대화를 명시적으로 언급할 때만 관련 컨텍스트가 포함됩니다.
  * 시스템 성능 향상: 불필요한 대화 내역 전송을 줄여 응답 속도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->