### PR TITLE
[Fix] PDF 이미지 변환 경로 오류 수정 및 이미지 전처리 인자 수정

### DIFF
--- a/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
+++ b/src/agents/workflows/subgraphs/step1_preprocessing/graph.py
@@ -199,8 +199,9 @@ def file_convert(state: AgentState) -> AgentState:
         return state
     pdf_path = local_input
 
-    # PDF -> 페이지 이미지
-    image_paths: List[Path] = preprocessing_utils.pdf_to_images(pdf_path, tmp_dir)
+    # PDF -> 페이지 이미지 (이미지 출력 경로는 PDF와 별도 디렉토리 사용)
+    images_out_dir = tmp_dir / "images"
+    image_paths: List[Path] = preprocessing_utils.pdf_to_images(pdf_path, images_out_dir)
     converted_images = [str(p) for p in image_paths]
 
     state["file_processing"] = _model_copy(fp, {"converted_images": converted_images})
@@ -230,9 +231,7 @@ def vision_llm(state: AgentState) -> AgentState:
     for img_ref in images:
         local_img = _localize_input_path(img_ref, tmp_dir_base)
         try:
-            proc_img = preprocessing_utils.preprocess_image(
-                local_img, local_img.with_suffix(".proc.png")
-            )
+            proc_img = preprocessing_utils.preprocess_image(str(local_img))
             prepared_images.append(str(proc_img))
         except Exception:
             prepared_images.append(str(local_img))


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #107 

## 🏷️ PR 타입
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 수정 (Documentation)
- [ ] 🎨 스타일 변경 (Style)
- [ ] ✅ 테스트 추가 (Test)

## 📝 작업 내용

- PDF 파일을 이미지로 변환할 때 이미지 출력 경로를 별도의 디렉토리로 변경
- `preprocess_image` 함수에서 `max_dim`에 잘못 전달된 `Path` 객체 수정

## 📸 스크린샷

<img width="916" height="160" alt="image" src="https://github.com/user-attachments/assets/ef300a0a-0f3a-4c29-946f-34c4f885dabc" />

## ✅ 체크리스트
- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [ ] 테스트를 작성하고 모두 통과했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 논의가 필요한 부분, 리뷰 시 유의사항 등을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 이미지 전처리 워크플로우의 내부 구조를 최적화하여 파일 관리 효율성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->